### PR TITLE
Mipmap support, Blitter and Uploader refactor

### DIFF
--- a/factory/src/barriers.rs
+++ b/factory/src/barriers.rs
@@ -1,0 +1,241 @@
+use {
+    crate::{
+        command::Encoder,
+        resource::{Handle, Image},
+    },
+    gfx_hal::{self, pso::PipelineStage, Backend},
+    std::{
+        iter::once,
+        ops::{BitOrAssign, Range},
+    },
+};
+
+#[derive(Debug)]
+struct ImageBarrier<B: Backend> {
+    /// The access flags controlling the image.
+    pub states: Range<gfx_hal::image::State>,
+    /// The image the barrier controls.
+    pub target: Handle<Image<B>>,
+    /// The source and destination Queue family IDs, for a [queue family ownership transfer](https://www.khronos.org/registry/vulkan/specs/1.0/html/vkspec.html#synchronization-queue-transfers)
+    /// Can be `None` to indicate no ownership transfer.
+    pub families: Option<Range<gfx_hal::queue::QueueFamilyId>>,
+    /// A `SubresourceRange` that defines which section of an image the barrier applies to.
+    pub range: gfx_hal::image::SubresourceRange,
+}
+
+impl<B: Backend> ImageBarrier<B> {
+    fn raw(&self) -> gfx_hal::memory::Barrier<'_, B> {
+        gfx_hal::memory::Barrier::Image {
+            states: self.states.clone(),
+            target: self.target.raw(),
+            families: self.families.clone(),
+            range: self.range.clone(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ImgBarrierCollector<B: Backend> {
+    target_stage: PipelineStage,
+    target_access: gfx_hal::image::Access,
+    target_layout: gfx_hal::image::Layout,
+    before_barriers: (Option<PipelineStage>, Vec<ImageBarrier<B>>),
+    after_barriers: (Option<PipelineStage>, Vec<ImageBarrier<B>>),
+    before_global: Option<(PipelineStage, gfx_hal::image::Access)>,
+    after_global: Option<(PipelineStage, gfx_hal::image::Access)>,
+}
+
+impl<B: Backend> ImgBarrierCollector<B> {
+    pub fn new(
+        target_stage: PipelineStage,
+        target_access: gfx_hal::image::Access,
+        target_layout: gfx_hal::image::Layout,
+    ) -> Self {
+        Self {
+            target_stage,
+            target_access,
+            target_layout,
+            before_barriers: (None, Vec::new()),
+            after_barriers: (None, Vec::new()),
+            before_global: None,
+            after_global: None,
+        }
+    }
+
+    fn add_last_access(&mut self, stage: PipelineStage, access: gfx_hal::image::Access) {
+        merge_opt(&mut self.before_global, (stage, access));
+    }
+
+    fn add_next_access(&mut self, stage: PipelineStage, access: gfx_hal::image::Access) {
+        merge_opt(&mut self.after_global, (stage, access));
+    }
+
+    fn add_before(&mut self, stage: PipelineStage, barrier: ImageBarrier<B>) {
+        let (mut_stage, vec) = &mut self.before_barriers;
+        *mut_stage.get_or_insert(stage) |= stage;
+        vec.push(barrier);
+    }
+
+    fn add_after(&mut self, stage: PipelineStage, barrier: ImageBarrier<B>) {
+        let (mut_stage, vec) = &mut self.after_barriers;
+        *mut_stage.get_or_insert(stage) |= stage;
+        vec.push(barrier);
+    }
+
+    pub fn add_image(
+        &mut self,
+        image: Handle<Image<B>>,
+        image_range: gfx_hal::image::SubresourceRange,
+        last_stage: PipelineStage,
+        last_access: gfx_hal::image::Access,
+        last_layout: gfx_hal::image::Layout,
+        next_stage: PipelineStage,
+        next_access: gfx_hal::image::Access,
+        next_layout: gfx_hal::image::Layout,
+    ) {
+        if last_layout == self.target_layout {
+            self.add_last_access(last_stage, last_access);
+        } else {
+            self.add_before(
+                last_stage,
+                ImageBarrier {
+                    states: (last_access, last_layout)..(self.target_access, self.target_layout),
+                    target: image.clone(),
+                    families: None,
+                    range: image_range.clone(),
+                },
+            );
+        }
+
+        if next_layout == self.target_layout {
+            self.add_next_access(next_stage, next_access);
+        } else {
+            self.add_after(
+                next_stage,
+                ImageBarrier {
+                    states: (self.target_access, self.target_layout)..(last_access, last_layout),
+                    target: image,
+                    families: None,
+                    range: image_range,
+                },
+            )
+        }
+    }
+
+    pub fn encode_before<C, L>(&mut self, encoder: &mut Encoder<'_, B, C, L>) {
+        let barriers_iter = self.before_barriers.1.iter().map(|b| b.raw());
+
+        if let Some((mut stage, access)) = self.before_global.take() {
+            if let Some(stage2) = self.before_barriers.0.take() {
+                stage |= stage2;
+            }
+            encoder.pipeline_barrier(
+                stage..self.target_stage,
+                gfx_hal::memory::Dependencies::empty(),
+                once(gfx_hal::memory::Barrier::AllImages(
+                    access..self.target_access,
+                ))
+                .chain(barriers_iter),
+            );
+        } else if let Some(stage) = self.before_barriers.0.take() {
+            encoder.pipeline_barrier(
+                stage..self.target_stage,
+                gfx_hal::memory::Dependencies::empty(),
+                barriers_iter,
+            );
+        }
+        self.before_barriers.1.clear();
+    }
+
+    pub fn encode_after<C, L>(&mut self, encoder: &mut Encoder<'_, B, C, L>) {
+        let barriers_iter = self.after_barriers.1.iter().map(|b| b.raw());
+
+        if let Some((mut stage, access)) = self.after_global.take() {
+            if let Some(stage2) = self.after_barriers.0.take() {
+                stage |= stage2;
+            }
+            encoder.pipeline_barrier(
+                self.target_stage..stage,
+                gfx_hal::memory::Dependencies::empty(),
+                once(gfx_hal::memory::Barrier::AllImages(
+                    self.target_access..access,
+                ))
+                .chain(barriers_iter),
+            );
+        } else if let Some(stage) = self.after_barriers.0.take() {
+            encoder.pipeline_barrier(
+                self.target_stage..stage,
+                gfx_hal::memory::Dependencies::empty(),
+                barriers_iter,
+            );
+        }
+        self.after_barriers.1.clear();
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct BufBarrierCollector {
+    target_stage: PipelineStage,
+    target_access: gfx_hal::buffer::Access,
+    before_global: Option<(PipelineStage, gfx_hal::buffer::Access)>,
+    after_global: Option<(PipelineStage, gfx_hal::buffer::Access)>,
+}
+
+impl BufBarrierCollector {
+    pub fn new(target_stage: PipelineStage, target_access: gfx_hal::buffer::Access) -> Self {
+        Self {
+            target_stage,
+            target_access,
+            before_global: None,
+            after_global: None,
+        }
+    }
+
+    pub fn add_buffer(
+        &mut self,
+        last: Option<(PipelineStage, gfx_hal::buffer::Access)>,
+        next: (PipelineStage, gfx_hal::buffer::Access),
+    ) {
+        if let Some(last) = last {
+            if last.1 != self.target_access {
+                merge_opt(&mut self.before_global, last);
+            }
+        }
+        if next.1 != self.target_access {
+            merge_opt(&mut self.after_global, next);
+        }
+    }
+
+    pub fn encode_before<B: Backend, C, L>(&mut self, encoder: &mut Encoder<'_, B, C, L>) {
+        if let Some((mut stage, access)) = self.after_global.take() {
+            encoder.pipeline_barrier(
+                stage..self.target_stage,
+                gfx_hal::memory::Dependencies::empty(),
+                once(gfx_hal::memory::Barrier::AllBuffers(
+                    access..self.target_access,
+                )),
+            );
+        }
+    }
+
+    pub fn encode_after<B: Backend, C, L>(&mut self, encoder: &mut Encoder<'_, B, C, L>) {
+        if let Some((mut stage, access)) = self.after_global.take() {
+            encoder.pipeline_barrier(
+                self.target_stage..stage,
+                gfx_hal::memory::Dependencies::empty(),
+                once(gfx_hal::memory::Barrier::AllBuffers(
+                    self.target_access..access,
+                )),
+            );
+        }
+    }
+}
+
+fn merge_opt<A: BitOrAssign, B: BitOrAssign>(opt: &mut Option<(A, B)>, with: (A, B)) {
+    if let Some((a, b)) = opt {
+        *a |= with.0;
+        *b |= with.1;
+    } else {
+        opt.replace(with);
+    }
+}

--- a/factory/src/blitter.rs
+++ b/factory/src/blitter.rs
@@ -1,0 +1,423 @@
+use {
+    crate::{
+        barriers::Barriers,
+        command::{
+            CommandBuffer, CommandPool, Families, Family, Graphics, IndividualReset, InitialState,
+            OneShot, PendingOnceState, PrimaryLevel, QueueId, RecordingState, Submission,
+        },
+        resource::{Handle, Image},
+        upload::ImageState,
+        util::Device,
+    },
+    gfx_hal::Device as _,
+    std::{collections::VecDeque, iter::once, ops::DerefMut, ops::Range},
+};
+
+#[derive(Debug)]
+pub struct Blitter<B: gfx_hal::Backend> {
+    family_ops: Vec<Option<parking_lot::Mutex<FamilyGraphicsOps<B>>>>,
+}
+
+fn subresource_to_range(
+    sub: &gfx_hal::image::SubresourceLayers,
+) -> gfx_hal::image::SubresourceRange {
+    gfx_hal::image::SubresourceRange {
+        aspects: sub.aspects,
+        levels: sub.level..sub.level + 1,
+        layers: sub.layers.clone(),
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct BlitRegion {
+    pub src: BlitImageState,
+    pub dst: BlitImageState,
+}
+
+#[derive(Debug, Clone)]
+pub struct BlitImageState {
+    subresource: gfx_hal::image::SubresourceLayers,
+    bounds: Range<gfx_hal::image::Offset>,
+    last_stage: gfx_hal::pso::PipelineStage,
+    last_access: gfx_hal::image::Access,
+    last_layout: gfx_hal::image::Layout,
+    next_stage: gfx_hal::pso::PipelineStage,
+    next_access: gfx_hal::image::Access,
+    next_layout: gfx_hal::image::Layout,
+}
+
+impl<B> Blitter<B>
+where
+    B: gfx_hal::Backend,
+{
+    /// # Safety
+    ///
+    /// `families` must belong to the `device`
+    pub(crate) unsafe fn new(
+        device: &Device<B>,
+        families: &Families<B>,
+    ) -> Result<Self, gfx_hal::device::OutOfMemory> {
+        let mut family_ops = Vec::new();
+        for family in families.as_slice() {
+            while family_ops.len() <= family.id().index {
+                family_ops.push(None);
+            }
+
+            family_ops[family.id().index] = Some(parking_lot::Mutex::new(FamilyGraphicsOps {
+                pool: family
+                    .create_pool(device)
+                    .map(|pool| pool.with_capability().unwrap())?,
+                initial: Vec::new(),
+                next: Vec::new(),
+                pending: VecDeque::new(),
+                read_barriers: Barriers::new(
+                    gfx_hal::pso::PipelineStage::TRANSFER,
+                    gfx_hal::buffer::Access::TRANSFER_READ,
+                    gfx_hal::image::Access::TRANSFER_READ,
+                ),
+                write_barriers: Barriers::new(
+                    gfx_hal::pso::PipelineStage::TRANSFER,
+                    gfx_hal::buffer::Access::TRANSFER_WRITE,
+                    gfx_hal::image::Access::TRANSFER_WRITE,
+                ),
+            }));
+        }
+
+        Ok(Blitter { family_ops })
+    }
+    /// `dst` should be `None` when blitting from the same image.
+    ///
+    /// # Safety
+    ///
+    /// `device` must be the same that was used to create this `Blitter`.
+    /// `image` must belong to the `device`.
+    /// `last` state must be valid for corresponding image layer at the time of command execution (after memory transfers).
+    /// `last` and `next` should contain at least `image.levels()` elements.
+    /// `image.levels()` must be greater than 1
+    pub unsafe fn fill_mips(
+        &self,
+        device: &Device<B>,
+        image: Handle<Image<B>>,
+        filter: gfx_hal::image::Filter,
+        last: impl IntoIterator<Item = ImageState>,
+        next: impl IntoIterator<Item = ImageState>,
+    ) -> Result<(), failure::Error> {
+        assert!(image.levels() > 1);
+
+        let aspects = image.format().surface_desc().aspects;
+
+        let transfer = gfx_hal::pso::PipelineStage::TRANSFER;
+        let src_optimal = gfx_hal::image::Layout::TransferSrcOptimal;
+        let read = gfx_hal::image::Access::TRANSFER_READ;
+
+        let mut last_iter = last.into_iter();
+        let mut next_iter = next.into_iter();
+
+        let mut src_last = last_iter.next().unwrap();
+        let mut src_next = next_iter.next().unwrap();
+        assert_eq!(src_last.queue, src_next.queue);
+
+        for (level, (dst_last, dst_next)) in (1..image.levels())
+            .into_iter()
+            .zip(last_iter.zip(next_iter))
+        {
+            assert_eq!(dst_last.queue, dst_next.queue);
+
+            let begin = level == 0;
+            let end = level == image.levels() - 1;
+
+            let blit = BlitRegion {
+                src: BlitImageState {
+                    subresource: gfx_hal::image::SubresourceLayers {
+                        aspects,
+                        level: level - 1,
+                        layers: 0..image.layers(),
+                    },
+                    bounds: gfx_hal::image::Offset::ZERO
+                        .into_bounds(&image.kind().level_extent(level - 1)),
+                    last_stage: if begin { src_last.stage } else { transfer },
+                    last_access: if begin { src_last.access } else { read },
+                    last_layout: if begin { src_last.layout } else { src_optimal },
+                    next_stage: src_next.stage,
+                    next_access: src_next.access,
+                    next_layout: src_next.layout,
+                },
+                dst: BlitImageState {
+                    subresource: gfx_hal::image::SubresourceLayers {
+                        aspects,
+                        level,
+                        layers: 0..image.layers(),
+                    },
+                    bounds: gfx_hal::image::Offset::ZERO
+                        .into_bounds(&image.kind().level_extent(level)),
+                    last_stage: dst_last.stage,
+                    last_access: dst_last.access,
+                    last_layout: dst_last.layout,
+                    next_stage: if end { dst_next.stage } else { transfer },
+                    next_access: if end { dst_next.access } else { read },
+                    next_layout: if end { dst_next.layout } else { src_optimal },
+                },
+            };
+
+            log::trace!("Blit: {:#?}", blit);
+            self.blit_image(device, src_last.queue, &image, &image, filter, Some(blit))?;
+            src_last = dst_last;
+            src_next = dst_next;
+        }
+        Ok(())
+    }
+
+    /// `dst` should be `None` when blitting from the same image.
+    ///
+    /// # Safety
+    ///
+    /// `device` must be the same that was used to create this `Blitter`.
+    /// `src` and `dst` must belong to the `device`.
+    /// regions' `last_*` states must be valid at the time of command execution (after memory transfers).
+    ///
+    pub unsafe fn blit_image(
+        &self,
+        device: &Device<B>,
+        queue_id: QueueId,
+        src_image: &Handle<Image<B>>,
+        dst_image: &Handle<Image<B>>,
+        filter: gfx_hal::image::Filter,
+        regions: impl IntoIterator<Item = BlitRegion>,
+    ) -> Result<(), failure::Error> {
+        let mut family_ops = self.family_ops[queue_id.family.index]
+            .as_ref()
+            .unwrap()
+            .lock();
+
+        family_ops.next_ops(device, queue_id.index)?;
+
+        let FamilyGraphicsOps {
+            next,
+            read_barriers,
+            write_barriers,
+            ..
+        } = family_ops.deref_mut();
+
+        let next_ops = next[queue_id.index].as_mut().unwrap();
+        let mut encoder = next_ops.command_buffer.encoder();
+
+        let regions = regions
+            .into_iter()
+            .map(|reg| {
+                read_barriers.add_image(
+                    src_image.clone(),
+                    subresource_to_range(&reg.src.subresource),
+                    reg.src.last_stage,
+                    reg.src.last_access,
+                    reg.src.last_layout,
+                    gfx_hal::image::Layout::TransferSrcOptimal,
+                    reg.src.next_stage,
+                    reg.src.next_access,
+                    reg.src.next_layout,
+                );
+
+                write_barriers.add_image(
+                    dst_image.clone(),
+                    subresource_to_range(&reg.dst.subresource),
+                    reg.dst.last_stage,
+                    reg.dst.last_access,
+                    reg.dst.last_layout,
+                    gfx_hal::image::Layout::TransferDstOptimal,
+                    reg.dst.next_stage,
+                    reg.dst.next_access,
+                    reg.dst.next_layout,
+                );
+
+                gfx_hal::command::ImageBlit {
+                    src_subresource: reg.src.subresource,
+                    src_bounds: reg.src.bounds,
+                    dst_subresource: reg.dst.subresource,
+                    dst_bounds: reg.dst.bounds,
+                }
+            })
+            .collect::<Vec<_>>();
+
+        // TODO: synchronize whatever possible on flush.
+        // Currently all barriers are inlined due to dependencies between blits.
+
+        read_barriers.encode_before(&mut encoder);
+        write_barriers.encode_before(&mut encoder);
+
+        encoder.blit_image(
+            src_image.raw(),
+            gfx_hal::image::Layout::TransferSrcOptimal,
+            dst_image.raw(),
+            gfx_hal::image::Layout::TransferDstOptimal,
+            filter,
+            regions,
+        );
+
+        read_barriers.encode_after(&mut encoder);
+        write_barriers.encode_after(&mut encoder);
+        Ok(())
+    }
+
+    /// Cleanup pending updates.
+    ///
+    /// # Safety
+    ///
+    /// `device` must be the same that was used to create this `Blitter`.
+    ///
+    pub(crate) unsafe fn cleanup(&mut self, device: &Device<B>) {
+        for blitter in self.family_ops.iter_mut() {
+            if let Some(blitter) = blitter {
+                blitter.get_mut().cleanup(device);
+            }
+        }
+    }
+
+    /// Flush new updates.
+    ///
+    /// # Safety
+    ///
+    /// `families` must be the same that was used to create this `Blitter`.
+    ///
+    pub(crate) unsafe fn flush(&mut self, families: &mut Families<B>) {
+        for family in families.as_slice_mut() {
+            let blitter = self.family_ops[family.id().index]
+                .as_mut()
+                .expect("Blitter must be initialized for all families");
+            blitter.get_mut().flush(family);
+        }
+    }
+
+    /// # Safety
+    ///
+    /// `device` must be the same that was used to create this `Blitter`.
+    /// `device` must be idle.
+    ///
+    pub(crate) unsafe fn dispose(&mut self, device: &Device<B>) {
+        self.family_ops.drain(..).for_each(|fu| {
+            fu.map(|fu| fu.into_inner().dispose(device));
+        });
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct FamilyGraphicsOps<B: gfx_hal::Backend> {
+    pool: CommandPool<B, Graphics, IndividualReset>,
+    initial: Vec<GraphicsOps<B, InitialState>>,
+    next: Vec<Option<GraphicsOps<B, RecordingState<OneShot>>>>,
+    pending: VecDeque<GraphicsOps<B, PendingOnceState>>,
+    read_barriers: Barriers<B>,
+    write_barriers: Barriers<B>,
+}
+
+#[derive(Debug)]
+struct GraphicsOps<B: gfx_hal::Backend, S> {
+    command_buffer: CommandBuffer<B, Graphics, S, PrimaryLevel, IndividualReset>,
+    fence: B::Fence,
+}
+
+impl<B> FamilyGraphicsOps<B>
+where
+    B: gfx_hal::Backend,
+{
+    unsafe fn flush(&mut self, family: &mut Family<B>) {
+        for (queue, next) in self
+            .next
+            .drain(..)
+            .enumerate()
+            .filter_map(|(i, x)| x.map(|x| (i, x)))
+        {
+            log::trace!("Flush blitter");
+            let (submit, command_buffer) = next.command_buffer.finish().submit_once();
+
+            family.queue_mut(queue).submit_raw_fence(
+                Some(Submission::new().submits(once(submit))),
+                Some(&next.fence),
+            );
+
+            self.pending.push_back(GraphicsOps {
+                command_buffer,
+                fence: next.fence,
+            });
+        }
+    }
+
+    unsafe fn next_ops(
+        &mut self,
+        device: &Device<B>,
+        queue: usize,
+    ) -> Result<&mut GraphicsOps<B, RecordingState<OneShot>>, failure::Error> {
+        while self.next.len() <= queue {
+            self.next.push(None);
+        }
+
+        let pool = &mut self.pool;
+
+        match &mut self.next[queue] {
+            Some(next) => Ok(next),
+            slot @ None => {
+                let initial: Result<_, failure::Error> = self.initial.pop().map_or_else(
+                    || {
+                        Ok(GraphicsOps {
+                            command_buffer: pool.allocate_buffers(1).remove(0),
+                            fence: device.create_fence(false)?,
+                        })
+                    },
+                    Ok,
+                );
+                let initial = initial?;
+
+                *slot = Some(GraphicsOps {
+                    command_buffer: initial.command_buffer.begin(OneShot, ()),
+                    fence: initial.fence,
+                });
+
+                Ok(slot.as_mut().unwrap())
+            }
+        }
+    }
+
+    /// Cleanup pending updates.
+    ///
+    /// # Safety
+    ///
+    /// `device` must be the same that was used with other methods of this instance.
+    ///
+    unsafe fn cleanup(&mut self, device: &Device<B>) {
+        while let Some(pending) = self.pending.pop_front() {
+            match device.get_fence_status(&pending.fence) {
+                Ok(false) => {
+                    self.pending.push_front(pending);
+                    return;
+                }
+                Err(gfx_hal::device::DeviceLost) => {
+                    panic!("Device lost error is not handled yet");
+                }
+                Ok(true) => self.initial.push(GraphicsOps {
+                    command_buffer: pending.command_buffer.mark_complete().reset(),
+                    fence: pending.fence,
+                }),
+            }
+        }
+    }
+
+    /// # Safety
+    ///
+    /// Device must be idle.
+    ///
+    unsafe fn dispose(mut self, device: &Device<B>) {
+        let pool = &mut self.pool;
+        self.pending.drain(..).for_each(|pending| {
+            device.destroy_fence(pending.fence);
+            pool.free_buffers(once(pending.command_buffer.mark_complete()));
+        });
+        self.initial.drain(..).for_each(|initial| {
+            device.destroy_fence(initial.fence);
+            pool.free_buffers(once(initial.command_buffer));
+        });
+        self.next.drain(..).filter_map(|n| n).for_each(|next| {
+            device.destroy_fence(next.fence);
+            pool.free_buffers(once(next.command_buffer));
+        });
+        drop(pool);
+        self.pool.dispose(device);
+    }
+}

--- a/factory/src/blitter.rs
+++ b/factory/src/blitter.rs
@@ -86,7 +86,7 @@ where
 
         Ok(Blitter { family_ops })
     }
-    /// `dst` should be `None` when blitting from the same image.
+    /// Fill all mip levels from the first level of provided image.
     ///
     /// # Safety
     ///
@@ -169,7 +169,7 @@ where
         Ok(())
     }
 
-    /// `dst` should be `None` when blitting from the same image.
+    /// Blit provided regions of `src_image` to `dst_image`.
     ///
     /// # Safety
     ///

--- a/factory/src/blitter.rs
+++ b/factory/src/blitter.rs
@@ -176,6 +176,7 @@ where
     /// `device` must be the same that was used to create this `Blitter`.
     /// `src` and `dst` must belong to the `device`.
     /// regions' `last_*` states must be valid at the time of command execution (after memory transfers).
+    /// All regions must have distinct subresource layer and level combination.
     ///
     pub unsafe fn blit_image(
         &self,

--- a/factory/src/factory.rs
+++ b/factory/src/factory.rs
@@ -455,7 +455,7 @@ where
     /// that reads content of the image layers the `next` must match image usage state in that operation.
     pub unsafe fn upload_image<T>(
         &self,
-        image: &Image<B>,
+        image: Handle<Image<B>>,
         data_width: u32,
         data_height: u32,
         image_layers: SubresourceLayers,

--- a/factory/src/factory.rs
+++ b/factory/src/factory.rs
@@ -1,5 +1,6 @@
 use {
     crate::{
+        blitter::Blitter,
         command::{
             families_from_device, CommandPool, Families, Family, FamilyId, Fence, QueueType, Reset,
         },
@@ -83,6 +84,7 @@ pub struct Factory<B: Backend> {
     resources: ManuallyDrop<ResourceHub<B>>,
     epochs: Vec<parking_lot::RwLock<Vec<u64>>>,
     uploader: Uploader<B>,
+    blitter: Blitter<B>,
     families_indices: Vec<usize>,
     #[derivative(Debug = "ignore")]
     device: Device<B>,
@@ -110,6 +112,8 @@ where
             // Device is idle.
             self.uploader.dispose(&self.device);
             log::trace!("Uploader disposed");
+            self.blitter.dispose(&self.device);
+            log::trace!("Blitter disposed");
             std::ptr::read(&mut *self.resources).dispose(
                 &self.device,
                 self.heaps.get_mut(),
@@ -506,6 +510,11 @@ where
         )
     }
 
+    /// Get blitter instance
+    pub fn blitter(&self) -> &Blitter<B> {
+        &self.blitter
+    }
+
     /// Create rendering surface from window.
     pub fn create_surface(&mut self, window: std::sync::Arc<winit::Window>) -> Surface<B> {
         Surface::new(&self.instance, window)
@@ -796,6 +805,7 @@ where
         let complete = self.complete_epochs();
         unsafe {
             self.uploader.cleanup(&self.device);
+            self.blitter.cleanup(&self.device);
             self.resources.cleanup(
                 &self.device,
                 self.heaps.get_mut(),
@@ -813,9 +823,15 @@ where
         unsafe { self.uploader.flush(families) }
     }
 
+    /// Flush blits
+    pub fn flush_blits(&mut self, families: &mut Families<B>) {
+        unsafe { self.blitter.flush(families) }
+    }
+
     /// Flush uploads and cleanup unused resources.
     pub fn maintain(&mut self, families: &mut Families<B>) {
         self.flush_uploads(families);
+        self.flush_blits(families);
         self.cleanup(families);
     }
 
@@ -1062,6 +1078,7 @@ where
         heaps: ManuallyDrop::new(parking_lot::Mutex::new(heaps)),
         resources: ManuallyDrop::new(ResourceHub::default()),
         uploader: unsafe { Uploader::new(&device, &families) }?,
+        blitter: unsafe { Blitter::new(&device, &families) }?,
         families_indices: families.indices().into(),
         epochs,
         device,

--- a/factory/src/lib.rs
+++ b/factory/src/lib.rs
@@ -17,6 +17,7 @@ use rendy_resource as resource;
 use rendy_util as util;
 use rendy_wsi as wsi;
 
+mod barriers;
 mod config;
 mod factory;
 mod upload;

--- a/factory/src/lib.rs
+++ b/factory/src/lib.rs
@@ -18,6 +18,7 @@ use rendy_util as util;
 use rendy_wsi as wsi;
 
 mod barriers;
+mod blitter;
 mod config;
 mod factory;
 mod upload;

--- a/graph/src/node/render/group/simple.rs
+++ b/graph/src/node/render/group/simple.rs
@@ -57,6 +57,14 @@ pub trait SimpleGraphicsPipelineDesc<B: Backend, T: ?Sized>: std::fmt::Debug {
     /// Simple graphics pipeline implementation
     type Pipeline: SimpleGraphicsPipeline<B, T>;
 
+    /// Make simple render group builder.
+    fn builder(self) -> DescBuilder<B, T, SimpleRenderGroupDesc<Self>>
+    where
+        Self: Sized,
+    {
+        SimpleRenderGroupDesc { inner: self }.builder()
+    }
+
     /// Get set or buffer resources the node uses.
     fn buffers(&self) -> Vec<BufferAccess> {
         Vec::new()
@@ -171,10 +179,7 @@ pub trait SimpleGraphicsPipeline<B: Backend, T: ?Sized>:
     where
         Self::Desc: Default,
     {
-        SimpleRenderGroupDesc {
-            inner: Self::Desc::default(),
-        }
-        .builder()
+        Self::Desc::default().builder()
     }
 
     /// Prepare to record drawing commands.

--- a/graph/src/node/render/pass.rs
+++ b/graph/src/node/render/pass.rs
@@ -691,18 +691,19 @@ where
                 .enumerate()
                 .any(|(subpass_index, subpass)| {
                     subpass.groups.iter_mut().fold(false, |record, group| {
-                        record | group
-                            .prepare(
-                                factory,
-                                queue.id(),
-                                index,
-                                gfx_hal::pass::Subpass {
-                                    index: subpass_index,
-                                    main_pass: &render_pass,
-                                },
-                                aux,
-                            )
-                            .force_record()
+                        record
+                            | group
+                                .prepare(
+                                    factory,
+                                    queue.id(),
+                                    index,
+                                    gfx_hal::pass::Subpass {
+                                        index: subpass_index,
+                                        main_pass: &render_pass,
+                                    },
+                                    aux,
+                                )
+                                .force_record()
                     })
                 });
 

--- a/graph/src/node/render/pass.rs
+++ b/graph/src/node/render/pass.rs
@@ -690,8 +690,8 @@ where
                 .iter_mut()
                 .enumerate()
                 .any(|(subpass_index, subpass)| {
-                    subpass.groups.iter_mut().any(|group| {
-                        group
+                    subpass.groups.iter_mut().fold(false, |record, group| {
+                        record | group
                             .prepare(
                                 factory,
                                 queue.id(),

--- a/rendy/examples/sprite/main.rs
+++ b/rendy/examples/sprite/main.rs
@@ -17,7 +17,7 @@ use {
             present::PresentNode, render::*, Graph, GraphBuilder, GraphContext, NodeBuffer,
             NodeImage,
         },
-        memory::{Dynamic},
+        memory::Dynamic,
         mesh::{AsVertex, PosTex},
         resource::{Buffer, BufferInfo, DescriptorSet, DescriptorSetLayout, Escape, Handle},
         shader::{Shader, ShaderKind, SourceLanguage, StaticShaderInfo},

--- a/texture/src/format/image.rs
+++ b/texture/src/format/image.rs
@@ -168,7 +168,11 @@ impl TextureKind {
 }
 
 #[derive(Derivative, Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(default)
+)]
 #[derivative(Default)]
 pub struct ImageTextureConfig {
     /// Interpret the image as given format.

--- a/texture/src/texture.rs
+++ b/texture/src/texture.rs
@@ -11,6 +11,7 @@ use {
         format::{Component, Format, Swizzle},
         image, Backend,
     },
+    std::num::NonZeroU8,
 };
 
 /// Static image.
@@ -51,7 +52,7 @@ where
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum MipLevel {
     Auto,
-    Level(u8),
+    Level(NonZeroU8),
 }
 
 /// Generics-free texture builder.
@@ -85,7 +86,7 @@ impl<'a> TextureBuilder<'a> {
                 gfx_hal::image::WrapMode::Clamp,
             ),
             swizzle: Swizzle::NO,
-            mip_level: MipLevel::Auto,
+            mip_level: MipLevel::Level(NonZeroU8::new(1).unwrap()),
         }
     }
 
@@ -233,7 +234,7 @@ impl<'a> TextureBuilder<'a> {
         };
 
         let mip_levels = match self.mip_level {
-            MipLevel::Level(val) => val,
+            MipLevel::Level(val) => val.get(),
             MipLevel::Auto => match self.kind {
                 gfx_hal::image::Kind::D1(_, _) => 1,
                 gfx_hal::image::Kind::D2(w, h, _, _) => {

--- a/texture/src/texture.rs
+++ b/texture/src/texture.rs
@@ -285,7 +285,7 @@ impl<'a> TextureBuilder<'a> {
         // that here because we just created the image on the same factory right before.
         unsafe {
             factory.upload_image(
-                &image,
+                image.clone(),
                 self.data_width,
                 self.data_height,
                 image::SubresourceLayers {

--- a/texture/src/texture.rs
+++ b/texture/src/texture.rs
@@ -272,12 +272,11 @@ impl<'a> TextureBuilder<'a> {
             BufferTransform::Intact => &self.data,
             BufferTransform::AddPadding { stride, padding } => {
                 transformed_vec.reserve_exact(self.data.len() / stride * (stride + padding.len()));
-                transformed_vec.extend(self.data.chunks_exact(stride).flat_map(|chunk| {
-                    chunk
-                        .iter()
-                        .cloned()
-                        .chain(padding.iter().cloned())
-                }));
+                transformed_vec.extend(
+                    self.data
+                        .chunks_exact(stride)
+                        .flat_map(|chunk| chunk.iter().cloned().chain(padding.iter().cloned())),
+                );
 
                 &transformed_vec
             }
@@ -360,7 +359,10 @@ impl<'a> TextureBuilder<'a> {
 
 enum BufferTransform {
     Intact,
-    AddPadding { stride: usize, padding: &'static [u8] },
+    AddPadding {
+        stride: usize,
+        padding: &'static [u8],
+    },
 }
 
 fn double_swizzle(src: Swizzle, overlay: Swizzle) -> Swizzle {
@@ -404,7 +406,7 @@ fn find_compatible_format<B: Backend>(
 
 fn expand_format_channels(format: Format) -> Option<(Format, BufferTransform, Swizzle)> {
     const ONE_F16: u16 = 15360u16;
-    
+
     let t2_u8 = BufferTransform::AddPadding {
         stride: 2,
         padding: &[0u8, std::u8::MAX],
@@ -449,7 +451,7 @@ fn expand_format_channels(format: Format) -> Option<(Format, BufferTransform, Sw
         stride: 12,
         padding: cast_slice(&[std::u32::MAX]),
     };
-    
+
     let t3_f32 = BufferTransform::AddPadding {
         stride: 12,
         padding: cast_slice(&[1.0f32]),

--- a/texture/src/texture.rs
+++ b/texture/src/texture.rs
@@ -5,7 +5,7 @@ use {
         memory::Data,
         pixel::AsPixel,
         resource::{Escape, Handle, Image, ImageInfo, ImageView, ImageViewInfo, Sampler},
-        util::cast_cow,
+        util::{cast_cow, cast_slice},
     },
     gfx_hal::{
         format::{Component, Format, Swizzle},
@@ -271,12 +271,12 @@ impl<'a> TextureBuilder<'a> {
         let buffer: &[u8] = match transform {
             BufferTransform::Intact => &self.data,
             BufferTransform::AddPadding { stride, padding } => {
-                transformed_vec.reserve_exact(self.data.len() / stride * (stride + padding));
+                transformed_vec.reserve_exact(self.data.len() / stride * (stride + padding.len()));
                 transformed_vec.extend(self.data.chunks_exact(stride).flat_map(|chunk| {
                     chunk
                         .iter()
                         .cloned()
-                        .chain(std::iter::repeat(0).take(padding))
+                        .chain(padding.iter().cloned())
                 }));
 
                 &transformed_vec
@@ -360,7 +360,7 @@ impl<'a> TextureBuilder<'a> {
 
 enum BufferTransform {
     Intact,
-    AddPadding { stride: usize, padding: usize },
+    AddPadding { stride: usize, padding: &'static [u8] },
 }
 
 fn double_swizzle(src: Swizzle, overlay: Swizzle) -> Swizzle {
@@ -403,69 +403,89 @@ fn find_compatible_format<B: Backend>(
 }
 
 fn expand_format_channels(format: Format) -> Option<(Format, BufferTransform, Swizzle)> {
-    let t2to4_8 = BufferTransform::AddPadding {
+    const ONE_F16: u16 = 15360u16;
+    
+    let t2_u8 = BufferTransform::AddPadding {
         stride: 2,
-        padding: 2,
+        padding: &[0u8, std::u8::MAX],
     };
 
-    let t2to4_16 = BufferTransform::AddPadding {
+    let t2_u16 = BufferTransform::AddPadding {
         stride: 4,
-        padding: 4,
+        padding: cast_slice(&[0u16, std::u16::MAX]),
     };
 
-    let t2to4_32 = BufferTransform::AddPadding {
+    let t2_f16 = BufferTransform::AddPadding {
+        stride: 4,
+        padding: cast_slice(&[0u16, ONE_F16]),
+    };
+
+    let t2_u32 = BufferTransform::AddPadding {
         stride: 8,
-        padding: 8,
+        padding: cast_slice(&[0u32, std::u32::MAX]),
     };
 
-    let t3to4_8 = BufferTransform::AddPadding {
+    let t2_f32 = BufferTransform::AddPadding {
+        stride: 8,
+        padding: cast_slice(&[0.0f32, 1.0f32]),
+    };
+
+    let t3_u8 = BufferTransform::AddPadding {
         stride: 3,
-        padding: 1,
+        padding: &[std::u8::MAX],
     };
 
-    let t3to4_16 = BufferTransform::AddPadding {
+    let t3_u16 = BufferTransform::AddPadding {
         stride: 6,
-        padding: 2,
+        padding: cast_slice(&[std::u16::MAX]),
     };
 
-    let t3to4_32 = BufferTransform::AddPadding {
+    let t3_f16 = BufferTransform::AddPadding {
+        stride: 6,
+        padding: cast_slice(&[ONE_F16]),
+    };
+
+    let t3_u32 = BufferTransform::AddPadding {
         stride: 12,
-        padding: 4,
+        padding: cast_slice(&[std::u32::MAX]),
+    };
+    
+    let t3_f32 = BufferTransform::AddPadding {
+        stride: 12,
+        padding: cast_slice(&[1.0f32]),
     };
 
     let intact = BufferTransform::Intact;
 
-    let rgzo = Swizzle(Component::R, Component::G, Component::Zero, Component::One);
-    let rgbo = Swizzle(Component::R, Component::G, Component::B, Component::One);
-    let bgro = Swizzle(Component::B, Component::G, Component::R, Component::One);
+    let rgba = Swizzle(Component::R, Component::G, Component::B, Component::A);
     let bgra = Swizzle(Component::B, Component::G, Component::R, Component::A);
 
     Some(match format {
         // Destination formats chosen according to this table
         // https://vulkan.gpuinfo.org/listformats.php
-        Format::Rg8Unorm => (Format::Rgba8Unorm, t2to4_8, rgzo),
-        Format::Rg8Inorm => (Format::Rgba8Inorm, t2to4_8, rgzo),
-        Format::Rg8Uscaled => (Format::Rgba8Uscaled, t2to4_8, rgzo),
-        Format::Rg8Iscaled => (Format::Rgba8Iscaled, t2to4_8, rgzo),
-        Format::Rg8Uint => (Format::Rgba8Uint, t2to4_8, rgzo),
-        Format::Rg8Int => (Format::Rgba8Int, t2to4_8, rgzo),
-        Format::Rg8Srgb => (Format::Rgba8Srgb, t2to4_8, rgzo),
+        Format::Rg8Unorm => (Format::Rgba8Unorm, t2_u8, rgba),
+        Format::Rg8Inorm => (Format::Rgba8Inorm, t2_u8, rgba),
+        Format::Rg8Uscaled => (Format::Rgba8Uscaled, t2_u8, rgba),
+        Format::Rg8Iscaled => (Format::Rgba8Iscaled, t2_u8, rgba),
+        Format::Rg8Uint => (Format::Rgba8Uint, t2_u8, rgba),
+        Format::Rg8Int => (Format::Rgba8Int, t2_u8, rgba),
+        Format::Rg8Srgb => (Format::Rgba8Srgb, t2_u8, rgba),
 
-        Format::Rgb8Unorm => (Format::Rgba8Unorm, t3to4_8, rgbo),
-        Format::Rgb8Inorm => (Format::Rgba8Inorm, t3to4_8, rgbo),
-        Format::Rgb8Uscaled => (Format::Rgba8Uscaled, t3to4_8, rgbo),
-        Format::Rgb8Iscaled => (Format::Rgba8Iscaled, t3to4_8, rgbo),
-        Format::Rgb8Uint => (Format::Rgba8Uint, t3to4_8, rgbo),
-        Format::Rgb8Int => (Format::Rgba8Int, t3to4_8, rgbo),
-        Format::Rgb8Srgb => (Format::Rgba8Srgb, t3to4_8, rgbo),
+        Format::Rgb8Unorm => (Format::Rgba8Unorm, t3_u8, rgba),
+        Format::Rgb8Inorm => (Format::Rgba8Inorm, t3_u8, rgba),
+        Format::Rgb8Uscaled => (Format::Rgba8Uscaled, t3_u8, rgba),
+        Format::Rgb8Iscaled => (Format::Rgba8Iscaled, t3_u8, rgba),
+        Format::Rgb8Uint => (Format::Rgba8Uint, t3_u8, rgba),
+        Format::Rgb8Int => (Format::Rgba8Int, t3_u8, rgba),
+        Format::Rgb8Srgb => (Format::Rgba8Srgb, t3_u8, rgba),
 
-        Format::Bgr8Unorm => (Format::Rgba8Unorm, t3to4_8, bgro),
-        Format::Bgr8Inorm => (Format::Rgba8Inorm, t3to4_8, bgro),
-        Format::Bgr8Uscaled => (Format::Rgba8Uscaled, t3to4_8, bgro),
-        Format::Bgr8Iscaled => (Format::Rgba8Iscaled, t3to4_8, bgro),
-        Format::Bgr8Uint => (Format::Rgba8Uint, t3to4_8, bgro),
-        Format::Bgr8Int => (Format::Rgba8Int, t3to4_8, bgro),
-        Format::Bgr8Srgb => (Format::Rgba8Srgb, t3to4_8, bgro),
+        Format::Bgr8Unorm => (Format::Rgba8Unorm, t3_u8, bgra),
+        Format::Bgr8Inorm => (Format::Rgba8Inorm, t3_u8, bgra),
+        Format::Bgr8Uscaled => (Format::Rgba8Uscaled, t3_u8, bgra),
+        Format::Bgr8Iscaled => (Format::Rgba8Iscaled, t3_u8, bgra),
+        Format::Bgr8Uint => (Format::Rgba8Uint, t3_u8, bgra),
+        Format::Bgr8Int => (Format::Rgba8Int, t3_u8, bgra),
+        Format::Bgr8Srgb => (Format::Rgba8Srgb, t3_u8, bgra),
 
         Format::Bgra8Unorm => (Format::Rgba8Unorm, intact, bgra),
         Format::Bgra8Inorm => (Format::Rgba8Inorm, intact, bgra),
@@ -475,29 +495,29 @@ fn expand_format_channels(format: Format) -> Option<(Format, BufferTransform, Sw
         Format::Bgra8Int => (Format::Rgba8Int, intact, bgra),
         Format::Bgra8Srgb => (Format::Rgba8Srgb, intact, bgra),
 
-        Format::Rg16Unorm => (Format::Rgba16Unorm, t2to4_16, rgzo),
-        Format::Rg16Inorm => (Format::Rgba16Inorm, t2to4_16, rgzo),
-        Format::Rg16Uscaled => (Format::Rgba16Uscaled, t2to4_16, rgzo),
-        Format::Rg16Iscaled => (Format::Rgba16Iscaled, t2to4_16, rgzo),
-        Format::Rg16Uint => (Format::Rgba16Uint, t2to4_16, rgzo),
-        Format::Rg16Int => (Format::Rgba16Int, t2to4_16, rgzo),
-        Format::Rg16Float => (Format::Rgba16Float, t2to4_16, rgzo),
+        Format::Rg16Unorm => (Format::Rgba16Unorm, t2_u16, rgba),
+        Format::Rg16Inorm => (Format::Rgba16Inorm, t2_u16, rgba),
+        Format::Rg16Uscaled => (Format::Rgba16Uscaled, t2_u16, rgba),
+        Format::Rg16Iscaled => (Format::Rgba16Iscaled, t2_u16, rgba),
+        Format::Rg16Uint => (Format::Rgba16Uint, t2_u16, rgba),
+        Format::Rg16Int => (Format::Rgba16Int, t2_u16, rgba),
+        Format::Rg16Float => (Format::Rgba16Float, t2_f16, rgba),
 
-        Format::Rgb16Unorm => (Format::Rgba16Unorm, t3to4_16, rgbo),
-        Format::Rgb16Inorm => (Format::Rgba16Inorm, t3to4_16, rgbo),
-        Format::Rgb16Uscaled => (Format::Rgba16Uscaled, t3to4_16, rgbo),
-        Format::Rgb16Iscaled => (Format::Rgba16Iscaled, t3to4_16, rgbo),
-        Format::Rgb16Uint => (Format::Rgba16Uint, t3to4_16, rgbo),
-        Format::Rgb16Int => (Format::Rgba16Int, t3to4_16, rgbo),
-        Format::Rgb16Float => (Format::Rgba16Float, t3to4_16, rgbo),
+        Format::Rgb16Unorm => (Format::Rgba16Unorm, t3_u16, rgba),
+        Format::Rgb16Inorm => (Format::Rgba16Inorm, t3_u16, rgba),
+        Format::Rgb16Uscaled => (Format::Rgba16Uscaled, t3_u16, rgba),
+        Format::Rgb16Iscaled => (Format::Rgba16Iscaled, t3_u16, rgba),
+        Format::Rgb16Uint => (Format::Rgba16Uint, t3_u16, rgba),
+        Format::Rgb16Int => (Format::Rgba16Int, t3_u16, rgba),
+        Format::Rgb16Float => (Format::Rgba16Float, t3_f16, rgba),
 
-        Format::Rg32Uint => (Format::Rgba32Uint, t2to4_32, rgzo),
-        Format::Rg32Int => (Format::Rgba32Int, t2to4_32, rgzo),
-        Format::Rg32Float => (Format::Rgba32Float, t2to4_32, rgzo),
+        Format::Rg32Uint => (Format::Rgba32Uint, t2_u32, rgba),
+        Format::Rg32Int => (Format::Rgba32Int, t2_u32, rgba),
+        Format::Rg32Float => (Format::Rgba32Float, t2_f32, rgba),
 
-        Format::Rgb32Uint => (Format::Rgba32Uint, t3to4_32, rgbo),
-        Format::Rgb32Int => (Format::Rgba32Int, t3to4_32, rgbo),
-        Format::Rgb32Float => (Format::Rgba32Float, t3to4_32, rgbo),
+        Format::Rgb32Uint => (Format::Rgba32Uint, t3_u32, rgba),
+        Format::Rgb32Int => (Format::Rgba32Int, t3_u32, rgba),
+        Format::Rgb32Float => (Format::Rgba32Float, t3_f32, rgba),
         // TODO: add more conversions
         _ => return None,
     })


### PR DESCRIPTION
Mipmaps are now autogenerated for all textures ~~unless explicitly disabled~~ based on TextureBuilder config, disabled by default.

Added batching to Uploader barriers. All transfer barriers and transitions are batched together inside the flush.

The lack of barrier batching is not ideal for blitter, but i think it's optimal in case of mipmaps anyway, due to all levels depending on previously generated ones. We need something more involved than that to support more general case optimally, but that's a problem for another day.