### PR TITLE
Bumps shaderc version to 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@
 
 A rendering engine based on [`gfx-hal`], which mimics the [`Vulkan`] API.
 
+## Building
+
+This library requires standard build tools for the target platforms, except in the case of windows - the spirv-compiler feature requires Ninja to be installed for compilation. https://ninja-build.org
+
 ## Features
 
 Most importantly `rendy` features safer API by checking important states and invariants.

--- a/shader/Cargo.toml
+++ b/shader/Cargo.toml
@@ -14,7 +14,7 @@ description = "Rendy's shader compilation tool"
 failure = "0.1"
 gfx-hal = "0.1"
 rendy-factory = { version = "0.1", path = "../factory" }
-shaderc = { version = "0.3", optional = true }
+shaderc = { version = "0.5", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_bytes = { version = "0.10.5", optional = true }
 


### PR DESCRIPTION
0.5.0 of Shaderc adds some stability features, bumps spirv-cross versions, and fixes up some building on linux allowing the platform shaderc libraries to be used. 

This version and future versions require ninja to be installed on the system to compile on windows. This is documented respectively in the README.md. We should get this requirement change out of the way now prior to the big 0.11 amethyst release.