### PR TITLE
Make winit optional

### DIFF
--- a/factory/Cargo.toml
+++ b/factory/Cargo.toml
@@ -22,6 +22,7 @@ serde-1 = [
 ]
 no-slow-safety-checks = ["rendy-util/no-slow-safety-checks"]
 profiler = [ "thread_profiler/thread_profiler" ]
+wsi-winit = ["rendy-wsi/winit", "winit"]
 
 [dependencies]
 rendy-memory = { version = "0.1", path = "../memory" }
@@ -45,5 +46,5 @@ parking_lot = "0.7"
 relevant = { version = "0.4", features = ["log", "backtrace"] }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 smallvec = "0.6"
-winit = "0.18"
+winit = { version = "0.18", optional = true }
 thread_profiler = "0.3"

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -43,5 +43,4 @@ log = "0.4"
 relevant = { version = "0.4", features = ["log", "backtrace"] }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 smallvec = "0.6"
-winit = "0.18"
 thread_profiler = "0.3"

--- a/graph/src/node/present.rs
+++ b/graph/src/node/present.rs
@@ -395,9 +395,11 @@ where
         assert_eq!(images.len(), 1);
 
         let input_image = images.into_iter().next().unwrap();
+        let extent = factory.get_surface_compatibility(&self.surface).0.current_extent.unwrap_or_else(|| ctx.get_image(input_image.id).expect("Context must contain node's image").kind().extent().into());
 
         let target = factory.create_target(
             self.surface,
+            extent,
             self.image_count,
             self.present_mode,
             gfx_hal::image::Usage::TRANSFER_DST,
@@ -487,8 +489,10 @@ where
             // TODO: use retired swapchains once available in hal and remove that wait
             factory.wait_idle().unwrap();
 
+            let extent = factory.get_surface_compatibility(self.target.surface()).0.current_extent.unwrap_or_else(|| ctx.get_image(self.input_image.id).expect("Context must contain node's image").kind().extent().into());
+
             self.target
-                .recreate(factory.physical(), factory.device())
+                .recreate(factory.physical(), factory.device(), extent)
                 .expect("Failed recreating swapchain");
 
             for data in self.per_image.drain(..) {

--- a/rendy/Cargo.toml
+++ b/rendy/Cargo.toml
@@ -36,7 +36,7 @@ util = ["rendy-util"]
 wsi = ["rendy-wsi"]
 
 base = [ "shader-compiler", "command", "descriptor", "factory", "frame", "graph", "memory", "mesh", "shader", "resource", "texture", "util", "wsi"]
-default = [ "base", "spirv-reflection" ]
+default = [ "base", "spirv-reflection", "rendy-factory/wsi-winit" ]
 
 mesh-obj = ["mesh", "rendy-mesh/obj"]
 texture-image = ["texture", "rendy-texture/image"]

--- a/rendy/examples/sprite/main.rs
+++ b/rendy/examples/sprite/main.rs
@@ -21,7 +21,7 @@ use {
         mesh::PosTex,
         resource::{Buffer, BufferInfo, DescriptorSet, DescriptorSetLayout, Escape, Handle},
         shader::{ShaderKind, SourceLanguage, StaticShaderInfo},
-        texture::{Texture, image::ImageTextureConfig},
+        texture::{image::ImageTextureConfig, Texture},
     },
 };
 
@@ -33,7 +33,7 @@ use rendy::mesh::AsVertex;
 
 use winit::{EventsLoop, WindowBuilder};
 
-use std::{io::BufReader, fs::File};
+use std::{fs::File, io::BufReader};
 
 #[cfg(feature = "dx12")]
 type Backend = rendy::dx12::Backend;
@@ -159,14 +159,13 @@ where
             "/examples/sprite/logo.png"
         ))?);
 
-        let texture_builder =
-            rendy::texture::image::load_from_image(
-                image_reader,
-                ImageTextureConfig {
-                    generate_mips: true,
-                    ..Default::default()
-                }
-            )?;
+        let texture_builder = rendy::texture::image::load_from_image(
+            image_reader,
+            ImageTextureConfig {
+                generate_mips: true,
+                ..Default::default()
+            },
+        )?;
 
         let texture = texture_builder
             .build(
@@ -371,8 +370,13 @@ fn main() {
 
     let mut graph_builder = GraphBuilder::<Backend, ()>::new();
 
+    let size = window
+        .get_inner_size()
+        .unwrap()
+        .to_physical(window.get_hidpi_factor());
+
     let color = graph_builder.create_image(
-        surface.kind(),
+        gfx_hal::image::Kind::D2(size.width as u32, size.height as u32, 1, 1),
         1,
         factory.get_surface_format(&surface),
         Some(gfx_hal::command::ClearValue::Color(

--- a/rendy/examples/triangle/main.rs
+++ b/rendy/examples/triangle/main.rs
@@ -253,12 +253,17 @@ fn main() {
 
     event_loop.poll_events(|_| ());
 
-    let surface = factory.create_surface(window.into());
+    let surface = factory.create_surface(&window);
 
     let mut graph_builder = GraphBuilder::<Backend, ()>::new();
 
+    let size = window
+        .get_inner_size()
+        .unwrap()
+        .to_physical(window.get_hidpi_factor());
+
     let color = graph_builder.create_image(
-        surface.kind(),
+        gfx_hal::image::Kind::D2(size.width as u32, size.height as u32, 1, 1),
         1,
         factory.get_surface_format(&surface),
         Some(gfx_hal::command::ClearValue::Color(

--- a/util/src/wrap.rs
+++ b/util/src/wrap.rs
@@ -108,7 +108,10 @@ where
     }
 
     /// Get reference to typed raw instance.
-    pub fn raw_typed<T: gfx_hal::Instance>(&self) -> Option<&T> {
+    pub fn raw_typed<T>(&self) -> Option<&T>
+    where
+        T: gfx_hal::Instance,
+    {
         if std::any::TypeId::of::<T::Backend>() == std::any::TypeId::of::<B>() {
             Some(
                 self.instance
@@ -121,7 +124,10 @@ where
     }
 
     /// Get mutable reference to typed raw instance.
-    pub fn raw_typed_mut<T: gfx_hal::Instance>(&mut self) -> Option<&mut T> {
+    pub fn raw_typed_mut<T>(&mut self) -> Option<&mut T>
+    where
+        T: gfx_hal::Instance,
+    {
         if std::any::TypeId::of::<T::Backend>() == std::any::TypeId::of::<B>() {
             Some(
                 self.instance

--- a/wsi/Cargo.toml
+++ b/wsi/Cargo.toml
@@ -33,4 +33,4 @@ failure = "0.1"
 log = "0.4"
 relevant = { version = "0.4", features = ["log", "backtrace"] }
 smallvec = "0.6"
-winit = "0.18"
+winit = { version = "0.18", optional = true }


### PR DESCRIPTION
Fixes #39

Also makes user provide extent for render target creation instead of using current extent of the surface.