### PR TITLE
Cleanup Cargo.toml files

### DIFF
--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -11,10 +11,11 @@ categories = ["rendering"]
 description = "Rendy's node synchronization tool"
 
 [features]
-profiler = [ "thread_profiler/thread_profiler" ]
+profiler = ["thread_profiler/thread_profiler"]
 
 [dependencies]
-gfx-hal = { version = "0.2" }
+gfx-hal = "0.2"
+rendy-util = { version = "0.1", path = "../util" }
 fnv = "1.0"
 log = "0.4"
 thread_profiler = "0.3"

--- a/command/Cargo.toml
+++ b/command/Cargo.toml
@@ -12,11 +12,13 @@ description = "Rendy's queues and commands tools"
 
 [features]
 no-slow-safety-checks = ["rendy-util/no-slow-safety-checks"]
+profiler = ["thread_profiler/thread_profiler"]
 
 [dependencies]
-gfx-hal = { version = "0.2" }
+gfx-hal = "0.2"
 derivative = "1.0"
 failure = "0.1"
 relevant = { version = "0.4", features = ["log", "backtrace"] }
 smallvec = "0.6"
 rendy-util = { version = "0.1", path = "../util" }
+thread_profiler = "0.3"

--- a/descriptor/Cargo.toml
+++ b/descriptor/Cargo.toml
@@ -12,7 +12,7 @@ description = "Rendy's descriptor allocator"
 
 [dependencies]
 derivative = "1.0"
-gfx-hal = { version = "0.2" }
+gfx-hal = "0.2"
 failure = "0.1"
 log = "0.4"
 relevant = { version = "0.4", features = ["log", "backtrace"] }

--- a/descriptor/src/allocator.rs
+++ b/descriptor/src/allocator.rs
@@ -122,13 +122,8 @@ where
     fn new_pool_size(&self, count: u32) -> u32 {
         MIN_SETS // at least MIN_SETS
             .max(count) // at least enough for allocation
-            .max(if self.total < MAX_SETS as u64 {
-                self.total as u32 // at least as much as was allocated so far
-            } else {
-                MAX_SETS
-            })
-            .next_power_of_two() // rounded up to 2^N
-            .min(MAX_SETS) // capped to MAX_SETS
+            .max(self.total.min(MAX_SETS as u64) as u32) // at least as much as was allocated so far capped to MAX_SETS
+            .next_power_of_two() // rounded up to nearest 2^N
     }
 
     unsafe fn dispose(mut self, device: &B::Device) {

--- a/factory/Cargo.toml
+++ b/factory/Cargo.toml
@@ -11,17 +11,17 @@ categories = ["rendering"]
 description = "Rendy's factory tool"
 
 [features]
-empty = ["gfx-backend-empty", "rendy-wsi/gfx-backend-empty", "rendy-util/empty"]
-dx12 = ["gfx-backend-dx12", "rendy-wsi/gfx-backend-dx12", "rendy-util/dx12"]
-metal = ["gfx-backend-metal", "rendy-wsi/gfx-backend-metal", "rendy-util/metal"]
-vulkan = ["gfx-backend-vulkan", "rendy-wsi/gfx-backend-vulkan", "rendy-util/vulkan"]
 serde-1 = [
     "serde",
     "rendy-memory/serde-1",
     "gfx-hal/serde",
 ]
+empty = ["rendy-util/gfx-backend-empty"]
+dx12 = ["rendy-util/gfx-backend-dx12"]
+metal = ["rendy-util/gfx-backend-metal"]
+vulkan = ["rendy-util/gfx-backend-vulkan"]
 no-slow-safety-checks = ["rendy-util/no-slow-safety-checks"]
-profiler = [ "thread_profiler/thread_profiler" ]
+profiler = ["thread_profiler/thread_profiler"]
 
 [dependencies]
 rendy-memory = { version = "0.1", path = "../memory" }
@@ -31,12 +31,7 @@ rendy-descriptor = { version = "0.1", path = "../descriptor" }
 rendy-wsi = { version = "0.1", path = "../wsi" }
 rendy-util = { version = "0.1", path = "../util" }
 
-gfx-hal = { version = "0.2" }
-gfx-backend-empty = { version = "0.2", optional = true }
-gfx-backend-dx12  = { version = "0.2", optional = true }
-gfx-backend-metal = { version = "0.2", optional = true }
-gfx-backend-vulkan = { version = "0.2", optional = true }
-
+gfx-hal = "0.2"
 derivative = "1.0"
 either = "1.0"
 failure = "0.1"
@@ -45,5 +40,4 @@ parking_lot = "0.7"
 relevant = { version = "0.4", features = ["log", "backtrace"] }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 smallvec = "0.6"
-winit = "0.19"
 thread_profiler = "0.3"

--- a/factory/src/config.rs
+++ b/factory/src/config.rs
@@ -179,7 +179,9 @@ unsafe impl HeapsConfigure for BasicHeapsConfigure {
                         block_size_granularity: 256.min(
                             (properties.memory_heaps[mt.heap_index] / 4096).next_power_of_two(),
                         ),
-                        min_device_allocation: _1mb.min(properties.memory_heaps[mt.heap_index] / 1048).next_power_of_two(),
+                        min_device_allocation: _1mb
+                            .min(properties.memory_heaps[mt.heap_index] / 1048)
+                            .next_power_of_two(),
                         max_chunk_size: _32mb.min(
                             (properties.memory_heaps[mt.heap_index] / 128).next_power_of_two(),
                         ),

--- a/factory/src/lib.rs
+++ b/factory/src/lib.rs
@@ -23,4 +23,4 @@ mod config;
 mod factory;
 mod upload;
 
-pub use crate::{config::*, factory::*, upload::*, blitter::*, barriers::*};
+pub use crate::{barriers::*, blitter::*, config::*, factory::*, upload::*};

--- a/frame/Cargo.toml
+++ b/frame/Cargo.toml
@@ -10,15 +10,22 @@ keywords = ["graphics", "gfx-hal", "rendy"]
 categories = ["rendering"]
 description = "Rendy's frame synchronization tool"
 
+[features]
+no-slow-safety-checks = ["rendy-util/no-slow-safety-checks"]
+profiler = ["thread_profiler/thread_profiler"]
+
 [dependencies]
-derivative = "1.0"
-either = "1.5"
-gfx-hal = { version = "0.2" }
-failure = "0.1"
-log = "0.4"
-relevant = { version = "0.4", features = ["log", "backtrace"] }
-smallvec = "0.6"
 rendy-command = { version = "0.1.0", path = "../command" }
 rendy-factory = { version = "0.1.0", path = "../factory" }
 rendy-memory = { version = "0.1.0", path = "../memory" }
 rendy-resource = { version = "0.1.0", path = "../resource" }
+rendy-util = { version = "0.1.0", path = "../util" }
+
+derivative = "1.0"
+either = "1.5"
+gfx-hal = "0.2"
+failure = "0.1"
+log = "0.4"
+relevant = { version = "0.4", features = ["log", "backtrace"] }
+smallvec = "0.6"
+thread_profiler = "0.3"

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -11,11 +11,12 @@ categories = ["rendering"]
 description = "Rendy's render graph"
 
 [features]
-empty = ["gfx-backend-empty", "rendy-wsi/gfx-backend-empty", "rendy-factory/gfx-backend-empty", "rendy-util/empty"]
-dx12 = ["gfx-backend-dx12", "rendy-wsi/gfx-backend-dx12", "rendy-factory/gfx-backend-dx12", "rendy-util/dx12"]
-metal = ["gfx-backend-metal", "rendy-wsi/gfx-backend-metal", "rendy-factory/gfx-backend-metal", "rendy-util/metal"]
-vulkan = ["gfx-backend-vulkan", "rendy-wsi/gfx-backend-vulkan", "rendy-factory/gfx-backend-vulkan", "rendy-util/vulkan"]
-profiler = [ "thread_profiler/thread_profiler", "rendy-chain/profiler" ]
+empty = ["rendy-util/gfx-backend-empty"]
+dx12 = ["rendy-util/gfx-backend-dx12"]
+metal = ["rendy-util/gfx-backend-metal"]
+vulkan = ["rendy-util/gfx-backend-vulkan"]
+no-slow-safety-checks = ["rendy-util/no-slow-safety-checks"]
+profiler = ["thread_profiler/thread_profiler"]
 
 [dependencies]
 rendy-chain = { version = "0.1.0", path = "../chain" }
@@ -29,11 +30,7 @@ rendy-util = { version = "0.1.0", path = "../util" }
 rendy-wsi = { version = "0.1.0", path = "../wsi" }
 rendy-shader = { version = "0.1.0", path = "../shader" }
 
-gfx-hal = { version = "0.2" }
-gfx-backend-empty = { version = "0.2", optional = true }
-gfx-backend-dx12  = { version = "0.2", optional = true }
-gfx-backend-metal = { version = "0.2", optional = true }
-gfx-backend-vulkan = { version = "0.2", optional = true }
+gfx-hal = "0.2"
 
 either = "1.5"
 bitflags = "1.0"
@@ -43,5 +40,4 @@ log = "0.4"
 relevant = { version = "0.4", features = ["log", "backtrace"] }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 smallvec = "0.6"
-winit = "0.19"
 thread_profiler = "0.3"

--- a/graph/src/node/mod.rs
+++ b/graph/src/node/mod.rs
@@ -10,6 +10,7 @@ use {
         factory::Factory,
         frame::Frames,
         graph::GraphContext,
+        util::{rendy_with_metal_backend, rendy_without_metal_backend},
         BufferId, ImageId, NodeId,
     },
     gfx_hal::{queue::QueueFamilyId, Backend},
@@ -537,14 +538,16 @@ pub fn gfx_release_barriers<'a, B: Backend>(
     (bstart | istart..bend | iend, barriers)
 }
 
-/// Check if backend is metal.
-#[cfg(feature = "metal")]
-pub fn is_metal<B: Backend>() -> bool {
-    std::any::TypeId::of::<B>() == std::any::TypeId::of::<gfx_backend_metal::Backend>()
+rendy_with_metal_backend! {
+    /// Check if backend is metal.
+    pub fn is_metal<B: Backend>() -> bool {
+        std::any::TypeId::of::<B>() == std::any::TypeId::of::<rendy_util::metal::Backend>()
+    }
 }
 
-/// Check if backend is metal.
-#[cfg(not(feature = "metal"))]
-pub fn is_metal<B: Backend>() -> bool {
-    false
+rendy_without_metal_backend! {
+    /// Check if backend is metal.
+    pub fn is_metal<B: Backend>() -> bool {
+        false
+    }
 }

--- a/graph/src/node/present.rs
+++ b/graph/src/node/present.rs
@@ -391,11 +391,12 @@ where
         assert_eq!(images.len(), 1);
 
         let input_image = images.into_iter().next().unwrap();
-        let extent = ctx.get_image(input_image.id)
-                    .expect("Context must contain node's image")
-                    .kind()
-                    .extent()
-                    .into();
+        let extent = ctx
+            .get_image(input_image.id)
+            .expect("Context must contain node's image")
+            .kind()
+            .extent()
+            .into();
 
         let target = factory.create_target(
             self.surface,
@@ -489,11 +490,12 @@ where
             // TODO: use retired swapchains once available in hal and remove that wait
             factory.wait_idle().unwrap();
 
-            let extent = ctx.get_image(self.input_image.id)
-                        .expect("Context must contain node's image")
-                        .kind()
-                        .extent()
-                        .into();
+            let extent = ctx
+                .get_image(self.input_image.id)
+                .expect("Context must contain node's image")
+                .kind()
+                .extent()
+                .into();
 
             self.target
                 .recreate(factory.physical(), factory.device(), extent)

--- a/graph/src/node/present.rs
+++ b/graph/src/node/present.rs
@@ -391,17 +391,11 @@ where
         assert_eq!(images.len(), 1);
 
         let input_image = images.into_iter().next().unwrap();
-        let extent = factory
-            .get_surface_compatibility(&self.surface)
-            .0
-            .current_extent
-            .unwrap_or_else(|| {
-                ctx.get_image(input_image.id)
+        let extent = ctx.get_image(input_image.id)
                     .expect("Context must contain node's image")
                     .kind()
                     .extent()
-                    .into()
-            });
+                    .into();
 
         let target = factory.create_target(
             self.surface,
@@ -495,17 +489,11 @@ where
             // TODO: use retired swapchains once available in hal and remove that wait
             factory.wait_idle().unwrap();
 
-            let extent = factory
-                .get_surface_compatibility(self.target.surface())
-                .0
-                .current_extent
-                .unwrap_or_else(|| {
-                    ctx.get_image(self.input_image.id)
+            let extent = ctx.get_image(self.input_image.id)
                         .expect("Context must contain node's image")
                         .kind()
                         .extent()
-                        .into()
-                });
+                        .into();
 
             self.target
                 .recreate(factory.physical(), factory.device(), extent)

--- a/memory/Cargo.toml
+++ b/memory/Cargo.toml
@@ -14,7 +14,7 @@ description = "Rendy's memory manager"
 serde-1 = ["serde"]
 
 [dependencies]
-gfx-hal = { version = "0.2" }
+gfx-hal = "0.2"
 derivative = "1.0"
 failure = "0.1"
 log = "0.4"

--- a/memory/src/allocator/dynamic.rs
+++ b/memory/src/allocator/dynamic.rs
@@ -292,7 +292,8 @@ where
 
         // If smallest possible chunk size is larger then this allocator max allocation
         if min_size > self.max_allocation()
-            || (total_blocks < MIN_BLOCKS_PER_CHUNK as u64 && min_size >= self.min_device_allocation)
+            || (total_blocks < MIN_BLOCKS_PER_CHUNK as u64
+                && min_size >= self.min_device_allocation)
         {
             // Allocate memory block from device.
             let chunk = self.alloc_chunk_from_device(device, block_size, min_size)?;
@@ -310,7 +311,8 @@ where
         } else {
             let total_blocks = self.sizes[&block_size].total_blocks;
             let chunk_size =
-                (max_chunk_size.min(min_chunk_size.max(total_blocks * block_size)) / 2 + 1).next_power_of_two();
+                (max_chunk_size.min(min_chunk_size.max(total_blocks * block_size)) / 2 + 1)
+                    .next_power_of_two();
             let (block, allocated) = self.alloc_block(device, chunk_size)?;
             Ok((Chunk::from_block(block_size, block), allocated))
         }

--- a/mesh/Cargo.toml
+++ b/mesh/Cargo.toml
@@ -12,9 +12,9 @@ categories = ["rendering"]
 readme = "README.md"
 
 [features]
-no-slow-safety-checks = ["rendy-util/no-slow-safety-checks"]
 obj = ["wavefront_obj"]
 serde-1 = ["serde", "serde_bytes", "gfx-hal/serde", "smallvec/serde", "rendy-factory/serde-1"]
+no-slow-safety-checks = ["rendy-util/no-slow-safety-checks"]
 
 [dependencies]
 rendy-command = { version = "0.1.0", path = "../command" }
@@ -23,7 +23,7 @@ rendy-resource = { version = "0.1.0", path = "../resource" }
 rendy-factory = { version = "0.1.0", path = "../factory" }
 rendy-util = { version = "0.1.0", path = "../util" }
 
-gfx-hal = { version = "0.2" }
+gfx-hal = "0.2"
 
 failure = "0.1"
 serde = { version = "1.0", optional = true, features = ["derive"] }

--- a/rendy/Cargo.toml
+++ b/rendy/Cargo.toml
@@ -12,37 +12,45 @@ categories = ["rendering"]
 readme = "../README.md"
 
 [features]
-empty = ["rendy-factory/empty", "rendy-graph/empty", "rendy-wsi/empty", "gfx-backend-empty", "rendy-util/empty"]
-dx12 = ["rendy-factory/dx12", "rendy-graph/dx12", "rendy-wsi/dx12", "gfx-backend-dx12", "rendy-util/dx12"]
-metal = ["rendy-factory/metal", "rendy-graph/metal", "rendy-wsi/metal", "gfx-backend-metal", "rendy-util/metal"]
-vulkan = ["rendy-factory/vulkan", "rendy-graph/vulkan", "rendy-wsi/vulkan", "gfx-backend-vulkan", "rendy-util/vulkan"]
-serde-1 = ["gfx-hal/serde", "rendy-factory/serde-1", "rendy-mesh/serde-1", "rendy-texture/serde-1", "rendy-shader/serde-1", "rendy-util/serde-1"]
-no-slow-safety-checks = ["rendy-util/no-slow-safety-checks", "rendy-factory/no-slow-safety-checks"]
-shader-compiler = ["rendy-shader/shader-compiler"]
-spirv-reflection = ["rendy-shader/spirv-reflection" ]
-profiler = [ "rendy-texture/profiler", "rendy-graph/profiler", "rendy-factory/profiler" ]
+serde-1 = ["rendy-factory/serde-1", "rendy-mesh/serde-1", "rendy-texture/serde-1", "rendy-shader/serde-1", "rendy-util/serde-1"]
 
+# Rendy subcrates
 command = ["rendy-command"]
 descriptor = ["rendy-descriptor"]
 factory = ["rendy-factory", "command", "descriptor", "resource", "wsi"]
 frame = ["rendy-frame", "factory"]
 graph = ["rendy-graph", "frame"]
 memory = ["rendy-memory"]
-mesh = ["rendy-mesh", "factory", "util"]
+mesh = ["rendy-mesh", "factory"]
 shader = ["rendy-shader", "factory"]
 resource = ["rendy-resource", "memory"]
-texture = ["rendy-texture", "factory", "util"]
-util = ["rendy-util"]
+texture = ["rendy-texture", "factory"]
 wsi = ["rendy-wsi"]
 
-base = [ "shader-compiler", "command", "descriptor", "factory", "frame", "graph", "memory", "mesh", "shader", "resource", "texture", "util", "wsi"]
-default = [ "base", "spirv-reflection" ]
+# Common util features
+empty = ["rendy-util/gfx-backend-empty"]
+dx12 = ["rendy-util/gfx-backend-dx12"]
+metal = ["rendy-util/gfx-backend-metal"]
+vulkan = ["rendy-util/gfx-backend-vulkan"]
+no-slow-safety-checks = ["rendy-util/no-slow-safety-checks"]
+profiler = ["thread_profiler/thread_profiler"]
 
+# Base feature enables all subcrates
+base = ["command", "descriptor", "factory", "frame", "graph", "memory", "mesh", "shader", "resource", "texture", "wsi"]
+
+# Subcrate features relay.
 mesh-obj = ["mesh", "rendy-mesh/obj"]
 texture-image = ["texture", "rendy-texture/image"]
 texture-palette = ["texture", "rendy-texture/palette"]
+shader-compiler = ["rendy-shader/shader-compiler"]
+spirv-reflection = ["rendy-shader/spirv-reflection" ]
+wsi-winit = ["rendy-wsi/winit"]
 
-full = ["base", "mesh-obj", "texture-image", "texture-palette", "spirv-reflection" ]
+# Full feature set - all listed features except rendy-util's.
+full = ["base", "mesh-obj", "texture-image", "texture-palette", "spirv-reflection", "shader-compiler", "wsi-winit"]
+
+# Default feature set includes all subcrates and few commonly used features.
+default = [ "base", "shader-compiler", "spirv-reflection", "wsi-winit" ]
 
 [dependencies]
 rendy-command = { version = "0.1.0", path = "../command", optional = true }
@@ -55,26 +63,34 @@ rendy-mesh = { version = "0.1.0", path = "../mesh", optional = true }
 rendy-shader = { version = "0.1.0", path = "../shader", optional = true }
 rendy-resource = { version = "0.1.0", path = "../resource", optional = true }
 rendy-texture = { version = "0.1.0", path = "../texture", optional = true }
-rendy-util = { version = "0.1.0", path = "../util", optional = true }
+rendy-util = { version = "0.1.0", path = "../util" }
 rendy-wsi = { version = "0.1.0", path = "../wsi", optional = true }
 
-gfx-hal = { version = "0.2" }
-gfx-backend-empty = { version = "0.2", optional = true }
-gfx-backend-dx12  = { version = "0.2", optional = true }
-gfx-backend-metal = { version = "0.2", optional = true }
-gfx-backend-vulkan = { version = "0.2", optional = true }
+failure = "0.1"
+gfx-hal = "0.2"
+thread_profiler = "0.3"
 
 [dev-dependencies]
 genmesh = "0.6"
 nalgebra = "0.18"
 env_logger = "0.6"
-failure = "0.1"
 lazy_static = "1.0"
 log = "0.4"
-winit = "0.19"
 palette = "0.4"
 rand = "0.6"
 
 [[example]]
+name = "triangle"
+required-features = ["base", "wsi-winit"]
+
+[[example]]
 name = "sprite"
-required-features = ["texture-image"]
+required-features = ["base", "texture-image", "wsi-winit"]
+
+[[example]]
+name = "meshes"
+required-features = ["base", "wsi-winit"]
+
+[[example]]
+name = "quads"
+required-features = ["base", "wsi-winit"]

--- a/rendy/src/lib.rs
+++ b/rendy/src/lib.rs
@@ -11,6 +11,24 @@
     unused_import_braces,
     unused_qualifications
 )]
+
+#[doc(inline)]
+pub use rendy_util;
+
+pub use gfx_hal as hal;
+
+#[cfg(feature = "empty")]
+pub use rendy_util::empty;
+
+#[cfg(feature = "dx12")]
+pub use rendy_util::dx12;
+
+#[cfg(feature = "metal")]
+pub use rendy_util::metal;
+
+#[cfg(feature = "vulkan")]
+pub use rendy_util::vulkan;
+
 #[cfg(feature = "command")]
 #[doc(inline)]
 pub use rendy_command as command;
@@ -51,24 +69,6 @@ pub use rendy_shader as shader;
 #[doc(inline)]
 pub use rendy_texture as texture;
 
-#[cfg(feature = "util")]
-#[doc(inline)]
-pub use rendy_util as util;
-
 #[cfg(feature = "wsi")]
 #[doc(inline)]
 pub use rendy_wsi as wsi;
-
-pub use gfx_hal as hal;
-
-#[cfg(feature = "gfx-backend-empty")]
-pub use gfx_backend_empty as empty;
-
-#[cfg(feature = "gfx-backend-dx12")]
-pub use gfx_backend_dx12 as dx12;
-
-#[cfg(feature = "gfx-backend-metal")]
-pub use gfx_backend_metal as metal;
-
-#[cfg(feature = "gfx-backend-vulkan")]
-pub use gfx_backend_vulkan as vulkan;

--- a/resource/Cargo.toml
+++ b/resource/Cargo.toml
@@ -14,7 +14,7 @@ description = "Rendy's resource manager"
 no-slow-safety-checks = ["rendy-util/no-slow-safety-checks"]
 
 [dependencies]
-gfx-hal = { version = "0.2" }
+gfx-hal = "0.2"
 crossbeam-channel = "0.3"
 derivative = "1.0"
 failure = "0.1"

--- a/resource/src/image.rs
+++ b/resource/src/image.rs
@@ -291,7 +291,7 @@ fn match_kind(kind: Kind, view_kind: ViewKind, view_caps: ViewCapabilities) -> b
                 } else {
                     false
                 }
-            },
+            }
             _ => false,
         },
         Kind::D3(..) => {

--- a/shader/Cargo.toml
+++ b/shader/Cargo.toml
@@ -10,20 +10,20 @@ keywords = ["graphics", "gfx-hal", "rendy"]
 categories = ["rendering"]
 description = "Rendy's shader compilation tool"
 
+[features]
+shader-compiler = ["shaderc"]
+spirv-reflection = [ "spirv-reflect" ]
+serde-1 = ["serde", "serde_bytes"]
+
 [dependencies]
 smallvec = "0.6"
 derivative = "1.0"
 log = "0.4"
 failure = "0.1"
-gfx-hal = { version = "0.2" }
+gfx-hal = "0.2"
 rendy-factory = { version = "0.1", path = "../factory" }
 rendy-util = { version = "0.1", path = "../util" }
 shaderc = { version = "0.5", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_bytes = { version = "0.11", optional = true }
 spirv-reflect = { version = "0.2.1", optional = true }
-
-[features]
-shader-compiler = ["shaderc"]
-spirv-reflection = [ "spirv-reflect" ]
-serde-1 = ["serde", "serde_bytes"]

--- a/texture/Cargo.toml
+++ b/texture/Cargo.toml
@@ -12,8 +12,8 @@ description = "Rendy's texture"
 
 [features]
 no-slow-safety-checks = ["rendy-util/no-slow-safety-checks"]
-serde-1 = ["serde", "gfx-hal/serde", "rendy-factory/serde-1"]
-profiler = [ "thread_profiler/thread_profiler" ]
+serde-1 = ["serde", "gfx-hal/serde"]
+profile = ["thread_profiler/thread_profiler"]
 
 [dependencies]
 rendy-memory = { version = "0.1.0", path = "../memory" }
@@ -21,7 +21,7 @@ rendy-resource = { version = "0.1.0", path = "../resource" }
 rendy-factory = { version = "0.1.0", path = "../factory" }
 rendy-util = { version = "0.1.0", path = "../util" }
 
-gfx-hal = { version = "0.2" }
+gfx-hal = "0.2"
 
 derivative = "1.0"
 failure = "0.1"

--- a/texture/src/texture.rs
+++ b/texture/src/texture.rs
@@ -257,9 +257,7 @@ impl<'a> TextureBuilder<'a> {
             MipLevels::RawLevels(val) => (val.get(), false),
             MipLevels::GenerateAuto => match self.kind {
                 gfx_hal::image::Kind::D1(_, _) => (1, false),
-                gfx_hal::image::Kind::D2(w, h, _, _) => {
-                    (mip_levels_from_dims(w, h), true)
-                }
+                gfx_hal::image::Kind::D2(w, h, _, _) => (mip_levels_from_dims(w, h), true),
                 gfx_hal::image::Kind::D3(_, _, _) => (1, false),
             },
         };

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -11,22 +11,29 @@ categories = ["rendering"]
 description = "Rendy's utilities"
 
 [features]
+serde-1 = ["serde", "gfx-hal/serde"]
+
+# This list of features is common for many rendy's crates
+# All other crates should transitively enable feature for rendy-util crate
+# and not rely on the feature being enabled for that crate directly.
+# To conditionally enable token trees `rendy-util::with_*` macro should be used instead of
+# `cfg` attributes.
 empty = ["gfx-backend-empty"]
 dx12 = ["gfx-backend-dx12"]
 metal = ["gfx-backend-metal"]
 vulkan = ["gfx-backend-vulkan"]
 no-slow-safety-checks = []
-serde-1 = ["serde"]
 
 [dependencies]
-derivative = "1.0"
-lazy_static = "1.0"
-parking_lot = "0.7"
-fnv = "1.0"
-log = "0.4"
-serde = { version = "1.0", optional = true, features = ["derive"] }
-gfx-hal = { version = "0.2" }
+gfx-hal = "0.2"
 gfx-backend-empty = { version = "0.2", optional = true }
-gfx-backend-dx12  = { version = "0.2", optional = true }
+gfx-backend-dx12 = { version = "0.2", optional = true }
 gfx-backend-metal = { version = "0.2", optional = true }
 gfx-backend-vulkan = { version = "0.2", optional = true }
+derivative = "1.0"
+fnv = "1.0"
+lazy_static = "1.0"
+log = "0.4"
+parking_lot = "0.7"
+serde = { version = "1.0", optional = true, features = ["derive"] }
+thread_profiler = "0.3"

--- a/util/src/casts.rs
+++ b/util/src/casts.rs
@@ -1,5 +1,5 @@
 //! Contains functions for casting
-use std::borrow::Cow;
+use std::{any::TypeId, borrow::Cow};
 
 /// Cast vec of some arbitrary type into vec of bytes.
 /// Can lead to UB if allocator changes. Use with caution.
@@ -26,5 +26,34 @@ pub fn cast_cow<T: Copy>(cow: Cow<'_, [T]>) -> Cow<'_, [u8]> {
     match cow {
         Cow::Borrowed(slice) => Cow::Borrowed(cast_slice(slice)),
         Cow::Owned(vec) => Cow::Owned(cast_vec(vec)),
+    }
+}
+
+/// Casts identical types.
+/// Useful in generic environment where caller knows that two types are the same
+/// but Rust is not convinced.
+///
+/// # Panics
+///
+/// Panics if types are actually different.
+///
+/// # Example
+///
+/// ```
+/// # use std::any::TypeId;
+/// # fn foo<T: 'static>() {
+/// if TypeId::of::<T>() == TypeId::of::<u32>() {
+///     let value: T = identical_cast(42u32);
+/// }
+/// # }
+///
+/// ```
+pub fn identical_cast<T: 'static, U: 'static>(value: T) -> U {
+    assert_eq!(TypeId::of::<T>(), TypeId::of::<U>());
+    unsafe {
+        // We know types are the same.
+        let mut value = std::mem::ManuallyDrop::new(value);
+        let ptr: *mut T = &mut *value;
+        std::ptr::read(ptr as *mut U)
     }
 }

--- a/util/src/casts.rs
+++ b/util/src/casts.rs
@@ -40,6 +40,8 @@ pub fn cast_cow<T: Copy>(cow: Cow<'_, [T]>) -> Cow<'_, [u8]> {
 /// # Example
 ///
 /// ```
+/// # extern crate rendy_util;
+/// # use rendy_util::identical_cast;
 /// # use std::any::TypeId;
 /// # fn foo<T: 'static>() {
 /// if TypeId::of::<T>() == TypeId::of::<u32>() {

--- a/util/src/features.rs
+++ b/util/src/features.rs
@@ -1,0 +1,172 @@
+/// Resolve into input AST if empty backend is enabled.
+#[macro_export]
+#[cfg(feature = "gfx-backend-empty")]
+macro_rules! rendy_with_empty_backend {
+    ($($tt:tt)*) => { $($tt)* };
+}
+
+/// Resolve into input AST if empty backend is enabled.
+#[macro_export]
+#[cfg(not(feature = "gfx-backend-empty"))]
+macro_rules! rendy_with_empty_backend {
+    ($($tt:tt)*) => {};
+}
+
+/// Resolve into input AST if empty backend is disabled.
+#[macro_export]
+#[cfg(not(feature = "gfx-backend-empty"))]
+macro_rules! rendy_without_empty_backend {
+    ($($tt:tt)*) => { $($tt)* };
+}
+
+/// Resolve into input AST if empty backend is disabled.
+#[macro_export]
+#[cfg(feature = "gfx-backend-empty")]
+macro_rules! rendy_without_empty_backend {
+    ($($tt:tt)*) => {};
+}
+
+/// Resolve into input AST if dx12 backend is enabled.
+#[macro_export]
+#[cfg(feature = "gfx-backend-dx12")]
+macro_rules! rendy_with_dx12_backend {
+    ($($tt:tt)*) => { $($tt)* };
+}
+
+/// Resolve into input AST if dx12 backend is enabled.
+#[macro_export]
+#[cfg(not(feature = "gfx-backend-dx12"))]
+macro_rules! rendy_with_dx12_backend {
+    ($($tt:tt)*) => {};
+}
+
+/// Resolve into input AST if dx12 backend is disabled.
+#[macro_export]
+#[cfg(not(feature = "gfx-backend-dx12"))]
+macro_rules! rendy_without_dx12_backend {
+    ($($tt:tt)*) => { $($tt)* };
+}
+
+/// Resolve into input AST if dx12 backend is disabled.
+#[macro_export]
+#[cfg(feature = "gfx-backend-dx12")]
+macro_rules! rendy_without_dx12_backend {
+    ($($tt:tt)*) => {};
+}
+
+/// Resolve into input AST if metal backend is enabled.
+#[macro_export]
+#[cfg(feature = "gfx-backend-metal")]
+macro_rules! rendy_with_metal_backend {
+    ($($tt:tt)*) => { $($tt)* };
+}
+
+/// Resolve into input AST if metal backend is enabled.
+#[macro_export]
+#[cfg(not(feature = "gfx-backend-metal"))]
+macro_rules! rendy_with_metal_backend {
+    ($($tt:tt)*) => {};
+}
+
+/// Resolve into input AST if metal backend is disabled.
+#[macro_export]
+#[cfg(not(feature = "gfx-backend-metal"))]
+macro_rules! rendy_without_metal_backend {
+    ($($tt:tt)*) => { $($tt)* };
+}
+
+/// Resolve into input AST if metal backend is disabled.
+#[macro_export]
+#[cfg(feature = "gfx-backend-metal")]
+macro_rules! rendy_without_metal_backend {
+    ($($tt:tt)*) => {};
+}
+
+/// Resolve into input AST if vulkan backend is enabled.
+#[macro_export]
+#[cfg(feature = "gfx-backend-vulkan")]
+macro_rules! rendy_with_vulkan_backend {
+    ($($tt:tt)*) => { $($tt)* };
+}
+
+/// Resolve into input AST if vulkan backend is enabled.
+#[macro_export]
+#[cfg(not(feature = "gfx-backend-vulkan"))]
+macro_rules! rendy_with_vulkan_backend {
+    ($($tt:tt)*) => {};
+}
+
+/// Resolve into input AST if vulkan backend is disabled.
+#[macro_export]
+#[cfg(not(feature = "gfx-backend-vulkan"))]
+macro_rules! rendy_without_vulkan_backend {
+    ($($tt:tt)*) => { $($tt)* };
+}
+
+/// Resolve into input AST if vulkan backend is disabled.
+#[macro_export]
+#[cfg(feature = "gfx-backend-vulkan")]
+macro_rules! rendy_without_vulkan_backend {
+    ($($tt:tt)*) => {};
+}
+
+/// Resolve into input AST if rendy is requested to not perform slow safety checks.
+#[macro_export]
+#[cfg(feature = "no-slow-safety-checks")]
+macro_rules! rendy_without_slow_safety_checks {
+    ($($tt:tt)*) => { $($tt)* };
+}
+
+/// Resolve into input AST if rendy is requested to not perform slow safety checks.
+#[macro_export]
+#[cfg(not(feature = "no-slow-safety-checks"))]
+macro_rules! rendy_without_slow_safety_checks {
+    ($($tt:tt)*) => {};
+}
+
+/// Resolve into input AST if rendy is requested to perform slow safety checks.
+#[macro_export]
+#[cfg(not(feature = "no-slow-safety-checks"))]
+macro_rules! rendy_with_slow_safety_checks {
+    ($($tt:tt)*) => { $($tt)* };
+}
+
+/// Resolve into input AST if rendy is requested to perform slow safety checks.
+#[macro_export]
+#[cfg(feature = "no-slow-safety-checks")]
+macro_rules! rendy_with_slow_safety_checks {
+    ($($tt:tt)*) => {};
+}
+
+/// Execute arm with matching backend.
+/// If particular backend is disabled
+/// then its arm is stripped from compilation altogether.
+#[macro_export]
+macro_rules! rendy_backend_match {
+    ($target:path {
+        $(empty => $empty_code:block)?
+        $(dx12 => $dx12_code:block)?
+        $(metal => $metal_code:block)?
+        $(vulkan => $vulkan_code:block)?
+    }) => {{
+        $($crate::rendy_with_empty_backend!(if std::any::TypeId::of::<$target>() == std::any::TypeId::of::<$crate::empty::Backend>() { return $empty_code; }))?;
+        $($crate::rendy_with_dx12_backend!(if std::any::TypeId::of::<$target>() == std::any::TypeId::of::<$crate::dx12::Backend>() { return $dx12_code; }))?;
+        $($crate::rendy_with_metal_backend!(if std::any::TypeId::of::<$target>() == std::any::TypeId::of::<$crate::metal::Backend>() { return $metal_code; }))?;
+        $($crate::rendy_with_vulkan_backend!(if std::any::TypeId::of::<$target>() == std::any::TypeId::of::<$crate::vulkan::Backend>() { return $vulkan_code; }))?;
+
+        panic!("
+            Undefined backend requested.
+            Make sure feature for required backend is enabled.
+            Try to add `--features=vulkan` or if on macos `--features=metal`.
+        ")
+    }};
+
+    ($target:path as $back:ident => $code:block) => {{
+        $crate::rendy_backend_match!($target {
+            empty => { use $crate::empty as $back; $code }
+            dx12 => { use $crate::dx12 as $back; $code }
+            metal => { use $crate::metal as $back; $code }
+            vulkan => { use $crate::vulkan as $back; $code }
+        });
+    }};
+}

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -11,75 +11,23 @@
     unused_qualifications
 )]
 
-mod casts;
-mod slow;
-mod wrap;
-
-#[doc(inline)]
-pub mod types;
-
 pub use crate::{casts::*, slow::*, wrap::*};
 
-/// Implement ownership checking for value with `device: DeviceId` field.
-#[macro_export]
-macro_rules! device_owned {
-    ($type:ident<B $(, $arg:ident $(: $(?$sized:ident)* $($bound:path)|*)*)*> @ $getter:expr) => {
-        #[allow(unused_qualifications)]
-        impl<B $(, $arg)*> $type<B $(, $arg)*>
-        where
-            B: gfx_hal::Backend,
-            $(
-                $($arg: $(?$sized)* $($bound)*,)*
-            )*
-        {
-            /// Get owned id.
-            pub fn device_id(&self) -> $crate::DeviceId {
-                ($getter)(self)
-            }
+#[cfg(feature = "gfx-backend-empty")]
+pub use gfx_backend_empty as empty;
 
-            /// Assert specified device is owner.
-            pub fn assert_device_owner(&self, device: &$crate::Device<B>) {
-                assert_eq!(self.device_id(), device.id(), "Resource is not owned by specified device");
-            }
+#[cfg(feature = "gfx-backend-dx12")]
+pub use gfx_backend_dx12 as dx12;
 
-            /// Get owned id.
-            pub fn instance_id(&self) -> $crate::InstanceId {
-                self.device_id().instance
-            }
+#[cfg(feature = "gfx-backend-metal")]
+pub use gfx_backend_metal as metal;
 
-            /// Assert specified instance is owner.
-            pub fn assert_instance_owner(&self, instance: &$crate::Instance<B>) {
-                assert_eq!(self.instance_id(), instance.id(), "Resource is not owned by specified instance");
-            }
-        }
-    };
+#[cfg(feature = "gfx-backend-vulkan")]
+pub use gfx_backend_vulkan as vulkan;
 
-    ($type:ident<B $(, $arg:ident $(: $(?$sized:ident)* $($bound:path)|*)*)*>) => {
-        device_owned!($type<B $(, $arg $(: $(?$sized)* $($bound)|*)*)*> @ (|s: &Self| {s.device}));
-    };
-}
-
-/// Implement ownership checking for value with `instance: InstanceId` field.
-#[macro_export]
-macro_rules! instance_owned {
-    ($type:ident<B $(, $arg:ident)*>) => {
-        #[allow(unused_qualifications)]
-        impl<B $(, $arg)*> $type<B $(, $arg)*>
-        where
-            B: gfx_hal::Backend,
-            $(
-                $($arg: $bound)*,
-            )*
-        {
-            /// Get owned id.
-            pub fn instance_id(&self) -> $crate::InstanceId {
-                self.instance
-            }
-
-            /// Assert specified instance is owner.
-            pub fn assert_instance_owner(&self, instance: &Instance<B>) {
-                assert_eq!(self.instance_id(), instance.id());
-            }
-        }
-    };
-}
+#[macro_use]
+mod features;
+mod casts;
+mod slow;
+pub mod types;
+mod wrap;

--- a/util/src/slow.rs
+++ b/util/src/slow.rs
@@ -1,59 +1,27 @@
 //! Macros that do run-time safety checks. These can be disabled, but this increases
 //! the risk of unsafe behavior.
 //!
-//! NOTE: These currently are not disabled even if the feature is enabled. This will
-//! be fixed in a later release.
-//!
+
 /// `assert!` that is exists only if `"no-slow-safety-checks"` feature is not enabled.
-#[cfg(not(feature = "no-slow-safety-checks"))]
 #[macro_export]
 macro_rules! rendy_slow_assert {
-    ($($arg:tt)*) => {
-        assert!($($arg)*);
+    ($($tt:tt)*) => {
+        with_slow_safety_checks!(assert!($($tt)*));
     }
 }
 
 /// `assert_eq!` that is exists only if `"no-slow-safety-checks"` feature is not enabled.
-#[cfg(not(feature = "no-slow-safety-checks"))]
 #[macro_export]
 macro_rules! rendy_slow_assert_eq {
-    ($($arg:tt)*) => {
-        assert_eq!($($arg)*);
+    ($($tt:tt)*) => {
+        with_slow_safety_checks!(assert_eq!($($tt)*));
     }
 }
 
 /// `assert_ne!` that is exists only if `"no-slow-safety-checks"` feature is not enabled.
-#[cfg(not(feature = "no-slow-safety-checks"))]
 #[macro_export]
 macro_rules! rendy_slow_assert_ne {
-    ($($arg:tt)*) => {
-        assert_ne!($($arg)*);
-    }
-}
-
-/// `assert!` that is exists only if `"no-slow-safety-checks"` feature is not enabled.
-#[cfg(feature = "no-slow-safety-checks")]
-#[macro_export]
-macro_rules! rendy_slow_assert {
-    ($($arg:tt)*) => {
-        assert!($($arg)*);
-    }
-}
-
-/// `assert_eq!` that is exists only if `"no-slow-safety-checks"` feature is not enabled.
-#[cfg(feature = "no-slow-safety-checks")]
-#[macro_export]
-macro_rules! rendy_slow_assert_eq {
-    ($($arg:tt)*) => {
-        assert_eq!($($arg)*);
-    }
-}
-
-/// `assert_ne!` that is exists only if `"no-slow-safety-checks"` feature is not enabled.
-#[cfg(feature = "no-slow-safety-checks")]
-#[macro_export]
-macro_rules! rendy_slow_assert_ne {
-    ($($arg:tt)*) => {
-        assert_ne!($($arg)*);
+    ($($tt:tt)*) => {
+        with_slow_safety_checks!(assert_ne!($($tt)*));
     }
 }

--- a/util/src/wrap.rs
+++ b/util/src/wrap.rs
@@ -108,7 +108,10 @@ where
     }
 
     /// Get reference to typed raw instance.
-    pub fn raw_typed<T: gfx_hal::Instance>(&self) -> Option<&T> {
+    pub fn raw_typed<T>(&self) -> Option<&T>
+    where
+        T: gfx_hal::Instance,
+    {
         if std::any::TypeId::of::<T::Backend>() == std::any::TypeId::of::<B>() {
             Some(
                 self.instance
@@ -121,7 +124,10 @@ where
     }
 
     /// Get mutable reference to typed raw instance.
-    pub fn raw_typed_mut<T: gfx_hal::Instance>(&mut self) -> Option<&mut T> {
+    pub fn raw_typed_mut<T>(&mut self) -> Option<&mut T>
+    where
+        T: gfx_hal::Instance,
+    {
         if std::any::TypeId::of::<T::Backend>() == std::any::TypeId::of::<B>() {
             Some(
                 self.instance
@@ -210,4 +216,68 @@ where
     fn deref(&self) -> &B::Device {
         self.raw()
     }
+}
+
+/// Implement ownership checking for value with `device: DeviceId` field.
+#[macro_export]
+macro_rules! device_owned {
+    ($type:ident<B $(, $arg:ident $(: $(?$sized:ident)? $($bound:path)?)?)*> @ $getter:expr) => {
+        #[allow(unused_qualifications)]
+        impl<B $(, $arg)*> $type<B $(, $arg)*>
+        where
+            B: gfx_hal::Backend,
+            $(
+                $($arg: $(?$sized)* $($bound)?,)?
+            )*
+        {
+            /// Get owned id.
+            pub fn device_id(&self) -> $crate::DeviceId {
+                ($getter)(self)
+            }
+
+            /// Assert specified device is owner.
+            pub fn assert_device_owner(&self, device: &$crate::Device<B>) {
+                assert_eq!(self.device_id(), device.id(), "Resource is not owned by specified device");
+            }
+
+            /// Get owned id.
+            pub fn instance_id(&self) -> $crate::InstanceId {
+                self.device_id().instance
+            }
+
+            /// Assert specified instance is owner.
+            pub fn assert_instance_owner(&self, instance: &$crate::Instance<B>) {
+                assert_eq!(self.instance_id(), instance.id(), "Resource is not owned by specified instance");
+            }
+        }
+    };
+
+    ($type:ident<B $(, $arg:ident $(: $(?$sized:ident)? $($bound:path)?)?)*>) => {
+        device_owned!($type<B $(, $arg $(: $(?$sized)? $($bound)?)?)*> @ (|s: &Self| {s.device}));
+    };
+}
+
+/// Implement ownership checking for value with `instance: InstanceId` field.
+#[macro_export]
+macro_rules! instance_owned {
+    ($type:ident<B $(, $arg:ident $(: $(?$sized:ident)? $($bound:path)?)?)*>) => {
+        #[allow(unused_qualifications)]
+        impl<B $(, $arg)*> $type<B $(, $arg)*>
+        where
+            B: gfx_hal::Backend,
+            $(
+                $($arg: $(?$sized)? $($bound)?,)?
+            )*
+        {
+            /// Get owned id.
+            pub fn instance_id(&self) -> $crate::InstanceId {
+                self.instance
+            }
+
+            /// Assert specified instance is owner.
+            pub fn assert_instance_owner(&self, instance: &Instance<B>) {
+                assert_eq!(self.instance_id(), instance.id());
+            }
+        }
+    };
 }

--- a/wsi/Cargo.toml
+++ b/wsi/Cargo.toml
@@ -11,10 +11,10 @@ categories = ["rendering"]
 description = "Rendy's windowing support"
 
 [features]
-empty = ["gfx-backend-empty", "rendy-util/empty"]
-dx12 = ["gfx-backend-dx12", "rendy-util/dx12"]
-metal = ["gfx-backend-metal", "rendy-util/metal"]
-vulkan = ["gfx-backend-vulkan", "rendy-util/vulkan"]
+empty = ["rendy-util/empty"]
+dx12 = ["rendy-util/dx12"]
+metal = ["rendy-util/metal"]
+vulkan = ["rendy-util/vulkan"]
 no-slow-safety-checks = ["rendy-util/no-slow-safety-checks"]
 
 [dependencies]
@@ -22,15 +22,10 @@ rendy-memory = { version = "0.1.0", path = "../memory" }
 rendy-resource = { version = "0.1.0", path = "../resource" }
 rendy-util = { version = "0.1.0", path = "../util" }
 
-gfx-hal = { version = "0.2" }
-gfx-backend-empty = { version = "0.2", optional = true }
-gfx-backend-dx12  = { version = "0.2", optional = true }
-gfx-backend-metal = { version = "0.2", optional = true }
-gfx-backend-vulkan = { version = "0.2", optional = true }
-
+gfx-hal = "0.2"
 derivative = "1.0"
 failure = "0.1"
 log = "0.4"
 relevant = { version = "0.4", features = ["log", "backtrace"] }
 smallvec = "0.6"
-winit = "0.19"
+winit = { version = "0.19", optional = true }

--- a/wsi/src/lib.rs
+++ b/wsi/src/lib.rs
@@ -12,7 +12,7 @@
 )]
 
 use {
-    gfx_hal::{Backend, Device as _, window::Extent2D},
+    gfx_hal::{window::Extent2D, Backend, Device as _},
     rendy_resource::{Image, ImageInfo},
     rendy_util::{
         device_owned, instance_owned, rendy_with_dx12_backend, rendy_with_empty_backend,
@@ -156,10 +156,7 @@ where
     }
 
     /// Get current extent of the surface.
-    pub unsafe fn extent(
-        &self,
-        physical_device: &B::PhysicalDevice,
-    ) -> Option<Extent2D> {
+    pub unsafe fn extent(&self, physical_device: &B::PhysicalDevice) -> Option<Extent2D> {
         let (capabilities, _formats, _present_modes) = self.compatibility(physical_device);
         capabilities.current_extent
     }
@@ -412,7 +409,7 @@ where
     /// Recreate swapchain.
     ///
     /// #Safety
-    /// 
+    ///
     /// Current swapchain must be not in use.
     pub unsafe fn recreate(
         &mut self,


### PR DESCRIPTION
Remove requirement for enabling features transitively to all crates. All common features now
relayed through rendy-util.
Make winit optional.
Refactor backend matching macros.
cargo fmt run.
Fixes #39 #111

Those changes are mostly code move, renames etc.

P.S. Sorry for making this all in one PR