### PR TITLE
Don't wait for zero fences

### DIFF
--- a/factory/src/factory.rs
+++ b/factory/src/factory.rs
@@ -779,6 +779,10 @@ where
             .inspect(|f| f.assert_device_owner(&self.device))
             .collect::<SmallVec<[_; 32]>>();
 
+        if fences.is_empty() {
+            return Ok(true);
+        }
+
         let timeout = !unsafe {
             self.device
                 .wait_for_fences(fences.iter().map(|f| f.raw()), wait_for, timeout_ns)


### PR DESCRIPTION
I'm not sure if this is a bug in Rendy or (far more likely) me screwing up while following along with the triangle example, but it seems like if I dispose of a graph that's never been run I get a validation error:
```
2019-05-21 20:02:45,561 ERROR [gfx_backend_vulkan]
VALIDATION [VUID_Undefined (-1)] : vkWaitForFences: parameter fenceCount must be greater than 0.
object info: (type: UNKNOWN, hndl: 0)
```

I noticed this when trying to add support for window resizing by discarding the existing graph before creating a new one. The smallest snippet I could figure out that exhibits this is rather pathological, though:

```
use rendy::factory::{Config, Factory};
use rendy::graph::GraphBuilder;
use rendy::vulkan::Backend;

fn main() {
    env_logger::Builder::from_default_env().init();

    let config: Config = Default::default();
    let (mut factory, mut families): (Factory<Backend>, _) =
        rendy::factory::init(config).unwrap();

    GraphBuilder::<Backend, ()>::new()
        .build(&mut factory, &mut families, &mut ()).unwrap()
        .dispose(&mut factory, &());
}
```