### PR TITLE
Minor doc updates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,21 +34,21 @@ It checks invariants statically using marker types and dynamically with stored v
 ### Capability
 
 Queue family capability defines what operation queues of the family supports.
-`rendy` provides simple mechanism to prevent recording unsupported commands.
-Capability level can be stored statically by marking `Family` type with one of capability types: `Transfer`, `Graphics`, `Compute` or `General` (`Graphics` and `Compute` combined).
-Alternatively `Capability` type can be used instead of marker type, this way actual capability level can be checked dynamically.
+`rendy` provides simple mechanisms to prevent recording unsupported commands.
+A queue's capability level can be stored statically by marking the `Family` type with one of capability types: `Transfer`, `Graphics`, `Compute` or `General` (`Graphics` and `Compute` combined).
+Alternatively the `Capability` type can be used instead of the marker type, this way actual capability level can be checked dynamically.
 
 ### Command buffer
 
-`rendy` provides handy wrapper named `CommandBuffer`. In contrast to its raw counterpart this wrapper
-encodes crutial information about its state directly into type level.
-This means user can't accidentally:
-* record command unsupported by queue family it belongs to.
-* record command when command buffer is not in recording state.
-* record render pass command outside renderpass.
-* forget to finish recording buffer before submitting.
-* resubmit command buffer which was created for one time use.
-* record execution of primary buffer into secondary buffer.
+`rendy` provides a handy wrapper named `CommandBuffer`. In contrast to its raw counterpart this wrapper
+encodes crucial information about its state directly into the type.
+This means users can't accidentally:
+* record commands unsupported by queue family it belongs to.
+* record commands when a command buffer is not in recording state.
+* record render pass commands outside renderpass.
+* forget to finish recording a buffer before submitting.
+* resubmit a command buffer which was created for one time use.
+* record execution of a primary buffer into a secondary buffer.
 * etc
 
 ### Memory manager
@@ -60,10 +60,13 @@ This means user can't accidentally:
 ### Rendergraph
 
 `rendy`'s rendergraph allows writing rendering code in simple modular style.
-Making it much easier to compose a complex frame from simple parts.
-User defines nodes which declare buffers and images it reads and writes.
-Rendergraph takes responsibility for transient resource allocation and execution synchronization.
-User is responsible only for intra-node synchronization.
+Note that this is not a scene graph offered by high-level graphics libraries, where nodes in
+the graph correspond to complex objects in the world.  Instead it is a graph of render passes
+with different properties.
+This makes it much easier to compose a complex frame from simple parts.
+A ser defines nodes which declare which buffers and images it reads and writes and
+the rendergraph takes responsibility for transient resource allocation and execution synchronization.
+The user is responsible only for intra-node synchronization.
 
 `DynNode` implementation - `RenderPassNode` can be constructed from `RenderGroup`s collected into subpasses.
 `RenderPassNode` will do all work for render pass creating and inter-subpass synchronization.
@@ -79,7 +82,7 @@ and gives access to the unused copy.
 ### CPU-GPU data flow
 
 Rendy can help to send data between device and host.
-`Factory` can upload data to the device local memory choosing most appropriate technique for that.
+The `Factory` type can upload data to the device local memory choosing most appropriate technique for that.
 * Memory mapping will be used if device local memory happens to be cpu-visible.
 * Relatively small data will be uploaded directly to buffers.
 * Staging buffer will be used for bigger uploads or any image uploads.
@@ -97,10 +100,10 @@ Current *WIP* implementation will use `specs::World` as scene to render.
 ### Declarative pipelines - ***Planned***
 
 Pipelines and descriptor sets has declarative nature and it is much easier to define them declaratively.
-`rendy` provides `DescriptorSet` trait.
+`rendy` provides a trait for this called `DescriptorSet`.
 Deriving it will automatically generate code necessary for set creation, writing and binding.
-Deriving `GraphicsPipeline` trait will generate code for graphics pipeline creation and usage.
-Similar `ComputePipeline` trait exists for compute pipelines.
+Deriving the `GraphicsPipeline` trait will generate code for graphics pipeline creation and usage.
+A similar `ComputePipeline` trait exists for compute pipelines.
 
 #### Example
 
@@ -118,8 +121,8 @@ struct Example {
     texture: Texture,
 
     /// Raw `gfx-hal` objects can be used as well.
-    /// But this field will make binding of `Set<Example>` to command buffer to require unsafe operation
-    /// since it is user job to ensure that this raw image view is valid during command buffer execution.
+    /// But this field will make binding `Set<Example>` to a command buffer an unsafe operation
+    /// since it is the user's job to ensure that this raw image view is valid during command buffer execution.
     #[descriptor(unsafe, SampledImage)]
     foo: RawImageView,
 }
@@ -127,9 +130,10 @@ struct Example {
 
 ### Modularity
 
-Most of the features provided by rendy can be used independently from others.
+Most of the features provided by rendy can be used independently from each other
 This helps to keep API clean and hopefuly sound.
-Top-level umbrella crate `rendy` has feature for each subcrates so that they could be enabled separately (subcrate will also enable its depenencies).
+The top-level umbrella crate `rendy` has features for each subcrate so that they could be
+enabled separately (enabling a subcrate will also enable its depenencies).
 
 ## Who is using it?
 

--- a/chain/src/collect.rs
+++ b/chain/src/collect.rs
@@ -85,7 +85,7 @@ struct QueueData {
 }
 
 /// Calculate automatic `Chains` for nodes.
-/// This function tries to find most appropriate schedule for nodes execution.
+/// This function tries to find the most appropriate schedule for nodes execution.
 pub fn collect<Q>(nodes: Vec<Node>, max_queues: Q) -> Chains
 where
     Q: Fn(gfx_hal::queue::QueueFamilyId) -> usize,

--- a/chain/src/lib.rs
+++ b/chain/src/lib.rs
@@ -1,4 +1,4 @@
-//! This crate can derive synchronization required
+//! This crate can derive the synchronization required
 //! for the dependency chain of the whole execution graph.
 
 #![warn(

--- a/mesh/README.md
+++ b/mesh/README.md
@@ -5,8 +5,9 @@ Helper crate for `gfx-hal` to create and use meshes with vertex semantics.
 
 # Vertex semantics
 
-Vertex formats usually has semantics attached to field names.
-This crate provides traits and types to have semantics explicitly defined on the type level.
+Vertex formats usually have semantics attached to field names.  A common example is for a
+vertex to be composed of a position, normal, color and texture coordinate field.
+This crate provides traits and types to have semantics explicitly defined for a vertex at the type level.
 
 `Position`, `Normal`, `TexCoord` etc. are attributes that have unambiguous semantics.
 Users can define their own attribute types by implementing the `Attribute` trait.
@@ -20,8 +21,7 @@ The `Query` trait allows to get formatting info for several attributes at once.
 
 To define a custom vertex format type, the `AsVertexFormat` trait must be implemented providing a `VertexFormat` associated constant.
 
-`WithAttribute` can be implemented also for all attributes and `VertexFormat` associated constant in `AsVertexFormat` can be defined more clearly utilizing `WithAttribute` implementation.
-`Query` is automatically implemented.
+`WithAttribute` can be implemented also for all attributes and the `VertexFormat` associated constant in `AsVertexFormat` can be defined more clearly by utilizing the `WithAttribute` implementation.  `Query` is automatically implemented.
 
 # Mesh
 

--- a/resource/src/escape.rs
+++ b/resource/src/escape.rs
@@ -1,7 +1,15 @@
-//! Module provides wrapper for types that cannot be dropped silently.
-//! Usually such types are required to be returned to their creator.
-//! `Escape` wrapper help the user to do so by sending underlying value to the `Terminal` when it is dropped.
-//! Users are encouraged to dispose of the values manually while `Escape` be just a safety net.
+//! This module provides wrapper for types that cannot be dropped silently.
+//! Usually such types are required to be returned to their creator,
+//! for example many Vulkan resources must be destroyed by the same
+//! Vulkan instance that created them.  Because they need some outside
+//! context to be destroyed, Rust's `Drop` trait alone cannot handle them.
+//! The `Escape` wrapper helps the user handle these values by sending the 
+//! underlying value to a `Terminal` when it is dropped.  The user can 
+//! then remove those values from the `Terminal` elsewhere in the program 
+//! and destroy them however necessary.
+//! 
+//! Users are encouraged to dispose of values manually while using `Escape` 
+//! as just a safety net.
 
 use {
     crossbeam_channel::{Receiver, Sender, TryRecvError},


### PR DESCRIPTION
Mostly just making the language flow a little better in readme files and fixing a typo or two.

The main addition was to the module docs for `resource::escape`.