### PR TITLE
Raw string source shader support

### DIFF
--- a/rendy/Cargo.toml
+++ b/rendy/Cargo.toml
@@ -94,3 +94,7 @@ required-features = ["base", "wsi-winit"]
 [[example]]
 name = "quads"
 required-features = ["base", "wsi-winit"]
+
+[[example]]
+name = "source_shaders"
+required-features = ["base", "wsi-winit"]

--- a/rendy/examples/meshes/main.rs
+++ b/rendy/examples/meshes/main.rs
@@ -21,7 +21,7 @@ use {
         memory::Dynamic,
         mesh::{Mesh, Model, PosColorNorm},
         resource::{Buffer, BufferInfo, DescriptorSet, DescriptorSetLayout, Escape, Handle},
-        shader::{ShaderKind, SourceLanguage, SpirvShader, StaticShaderInfo},
+        shader::{PathBufShaderInfo, ShaderKind, SourceLanguage, SourceShaderInfo, SpirvShader},
         wsi::winit::{Event, EventsLoop, WindowBuilder, WindowEvent},
     },
     std::{cmp::min, mem::size_of, time},
@@ -43,15 +43,16 @@ type Backend = rendy::metal::Backend;
 type Backend = rendy::vulkan::Backend;
 
 lazy_static::lazy_static! {
-    static ref VERTEX: SpirvShader = StaticShaderInfo::new(
-        concat!(env!("CARGO_MANIFEST_DIR"), "/examples/meshes/shader.vert"),
+    static ref VERTEX: SpirvShader = SourceShaderInfo::new(
+        unsafe { std::str::from_utf8_unchecked(include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/examples/meshes/shader.vert"))) },
+        concat!(env!("CARGO_MANIFEST_DIR"), "/examples/meshes/shader.vert").into(),
         ShaderKind::Vertex,
         SourceLanguage::GLSL,
         "main",
     ).precompile().unwrap();
 
-    static ref FRAGMENT: SpirvShader = StaticShaderInfo::new(
-        concat!(env!("CARGO_MANIFEST_DIR"), "/examples/meshes/shader.frag"),
+    static ref FRAGMENT: SpirvShader = PathBufShaderInfo::new(
+        concat!(env!("CARGO_MANIFEST_DIR"), "/examples/meshes/shader.frag").into(),
         ShaderKind::Fragment,
         SourceLanguage::GLSL,
         "main",

--- a/rendy/examples/meshes/main.rs
+++ b/rendy/examples/meshes/main.rs
@@ -21,7 +21,7 @@ use {
         memory::Dynamic,
         mesh::{Mesh, Model, PosColorNorm},
         resource::{Buffer, BufferInfo, DescriptorSet, DescriptorSetLayout, Escape, Handle},
-        shader::{PathBufShaderInfo, ShaderKind, SourceLanguage, SourceShaderInfo, SpirvShader},
+        shader::{ShaderKind, SourceLanguage, SourceShaderInfo, SpirvShader},
         wsi::winit::{Event, EventsLoop, WindowBuilder, WindowEvent},
     },
     std::{cmp::min, mem::size_of, time},
@@ -44,14 +44,15 @@ type Backend = rendy::vulkan::Backend;
 
 lazy_static::lazy_static! {
     static ref VERTEX: SpirvShader = SourceShaderInfo::new(
-        unsafe { std::str::from_utf8_unchecked(include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/examples/meshes/shader.vert"))) },
+        include_str!("shader.vert"),
         concat!(env!("CARGO_MANIFEST_DIR"), "/examples/meshes/shader.vert").into(),
         ShaderKind::Vertex,
         SourceLanguage::GLSL,
         "main",
     ).precompile().unwrap();
 
-    static ref FRAGMENT: SpirvShader = PathBufShaderInfo::new(
+    static ref FRAGMENT: SpirvShader = SourceShaderInfo::new(
+        include_str!("shader.frag"),
         concat!(env!("CARGO_MANIFEST_DIR"), "/examples/meshes/shader.frag").into(),
         ShaderKind::Fragment,
         SourceLanguage::GLSL,

--- a/rendy/examples/quads/main.rs
+++ b/rendy/examples/quads/main.rs
@@ -29,7 +29,7 @@ use rendy::{
     memory::Dynamic,
     mesh::Color,
     resource::{Buffer, BufferInfo, DescriptorSet, DescriptorSetLayout, Escape, Handle},
-    shader::{Shader, ShaderKind, SourceLanguage, SpirvShader, StaticShaderInfo},
+    shader::{PathBufShaderInfo, Shader, ShaderKind, SourceLanguage, SpirvShader},
     wsi::winit::{EventsLoop, Window, WindowBuilder},
 };
 
@@ -56,22 +56,22 @@ struct PosVel {
 }
 
 lazy_static::lazy_static! {
-    static ref RENDER_VERTEX: SpirvShader = StaticShaderInfo::new(
-        concat!(env!("CARGO_MANIFEST_DIR"), "/examples/quads/render.vert"),
+    static ref RENDER_VERTEX: SpirvShader = PathBufShaderInfo::new(
+        concat!(env!("CARGO_MANIFEST_DIR"), "/examples/quads/render.vert").into(),
         ShaderKind::Vertex,
         SourceLanguage::GLSL,
         "main",
     ).precompile().unwrap();
 
-    static ref RENDER_FRAGMENT: SpirvShader = StaticShaderInfo::new(
-        concat!(env!("CARGO_MANIFEST_DIR"), "/examples/quads/render.frag"),
+    static ref RENDER_FRAGMENT: SpirvShader = PathBufShaderInfo::new(
+        concat!(env!("CARGO_MANIFEST_DIR"), "/examples/quads/render.frag").into(),
         ShaderKind::Fragment,
         SourceLanguage::GLSL,
         "main",
     ).precompile().unwrap();
 
-    static ref BOUNCE_COMPUTE: SpirvShader = StaticShaderInfo::new(
-        concat!(env!("CARGO_MANIFEST_DIR"), "/examples/quads/bounce.comp"),
+    static ref BOUNCE_COMPUTE: SpirvShader = PathBufShaderInfo::new(
+        concat!(env!("CARGO_MANIFEST_DIR"), "/examples/quads/bounce.comp").into(),
         ShaderKind::Compute,
         SourceLanguage::GLSL,
         "main",

--- a/rendy/examples/quads/main.rs
+++ b/rendy/examples/quads/main.rs
@@ -29,7 +29,7 @@ use rendy::{
     memory::Dynamic,
     mesh::Color,
     resource::{Buffer, BufferInfo, DescriptorSet, DescriptorSetLayout, Escape, Handle},
-    shader::{PathBufShaderInfo, Shader, ShaderKind, SourceLanguage, SpirvShader},
+    shader::{SourceShaderInfo, Shader, ShaderKind, SourceLanguage, SpirvShader},
     wsi::winit::{EventsLoop, Window, WindowBuilder},
 };
 
@@ -56,21 +56,24 @@ struct PosVel {
 }
 
 lazy_static::lazy_static! {
-    static ref RENDER_VERTEX: SpirvShader = PathBufShaderInfo::new(
+    static ref RENDER_VERTEX: SpirvShader = SourceShaderInfo::new(
+        include_str!("render.vert"),
         concat!(env!("CARGO_MANIFEST_DIR"), "/examples/quads/render.vert").into(),
         ShaderKind::Vertex,
         SourceLanguage::GLSL,
         "main",
     ).precompile().unwrap();
 
-    static ref RENDER_FRAGMENT: SpirvShader = PathBufShaderInfo::new(
+    static ref RENDER_FRAGMENT: SpirvShader = SourceShaderInfo::new(
+        include_str!("render.frag"),
         concat!(env!("CARGO_MANIFEST_DIR"), "/examples/quads/render.frag").into(),
         ShaderKind::Fragment,
         SourceLanguage::GLSL,
         "main",
     ).precompile().unwrap();
 
-    static ref BOUNCE_COMPUTE: SpirvShader = PathBufShaderInfo::new(
+    static ref BOUNCE_COMPUTE: SpirvShader = SourceShaderInfo::new(
+        include_str!("bounce.comp"),
         concat!(env!("CARGO_MANIFEST_DIR"), "/examples/quads/bounce.comp").into(),
         ShaderKind::Compute,
         SourceLanguage::GLSL,

--- a/rendy/examples/source_shaders/main.rs
+++ b/rendy/examples/source_shaders/main.rs
@@ -19,7 +19,7 @@ use rendy::{
     memory::Dynamic,
     mesh::PosColor,
     resource::{Buffer, BufferInfo, DescriptorSetLayout, Escape, Handle},
-    shader::{PathBufShaderInfo, ShaderKind, SourceLanguage, SpirvShader},
+    shader::{ShaderKind, SourceLanguage, SourceShaderInfo, SpirvShader},
     wsi::winit::{EventsLoop, WindowBuilder},
 };
 
@@ -39,15 +39,41 @@ type Backend = rendy::metal::Backend;
 type Backend = rendy::vulkan::Backend;
 
 lazy_static::lazy_static! {
-    static ref VERTEX: SpirvShader = PathBufShaderInfo::new(
-        concat!(env!("CARGO_MANIFEST_DIR"), "/examples/triangle/shader.vert").into(),
+    static ref VERTEX: SpirvShader = SourceShaderInfo::new(
+    "
+    #version 450
+    #extension GL_ARB_separate_shader_objects : enable
+
+    layout(location = 0) in vec3 pos;
+    layout(location = 1) in vec4 color;
+    layout(location = 0) out vec4 frag_color;
+
+    void main() {
+        frag_color = color;
+        gl_Position = vec4(pos, 1.0);
+    }
+    ",
+        "triangle.vert",
         ShaderKind::Vertex,
         SourceLanguage::GLSL,
         "main",
     ).precompile().unwrap();
 
-    static ref FRAGMENT: SpirvShader = PathBufShaderInfo::new(
-        concat!(env!("CARGO_MANIFEST_DIR"), "/examples/triangle/shader.frag").into(),
+    static ref FRAGMENT: SpirvShader = SourceShaderInfo::new(
+    "
+    #version 450
+    #extension GL_ARB_separate_shader_objects : enable
+
+    layout(early_fragment_tests) in;
+
+    layout(location = 0) in vec4 frag_color;
+    layout(location = 0) out vec4 color;
+
+    void main() {
+        color = frag_color;
+    }
+    ",
+        "triangle.frag",
         ShaderKind::Fragment,
         SourceLanguage::GLSL,
         "main",

--- a/rendy/examples/sprite/main.rs
+++ b/rendy/examples/sprite/main.rs
@@ -18,7 +18,7 @@ use rendy::{
     memory::Dynamic,
     mesh::PosTex,
     resource::{Buffer, BufferInfo, DescriptorSet, DescriptorSetLayout, Escape, Handle},
-    shader::{PathBufShaderInfo, ShaderKind, SourceLanguage, SpirvShader},
+    shader::{SourceShaderInfo, ShaderKind, SourceLanguage, SpirvShader},
     texture::{image::ImageTextureConfig, Texture},
     wsi::winit::{EventsLoop, WindowBuilder},
 };
@@ -41,14 +41,16 @@ type Backend = rendy::metal::Backend;
 type Backend = rendy::vulkan::Backend;
 
 lazy_static::lazy_static! {
-    static ref VERTEX: SpirvShader = PathBufShaderInfo::new(
+    static ref VERTEX: SpirvShader = SourceShaderInfo::new(
+        include_str!("shader.vert"),
         concat!(env!("CARGO_MANIFEST_DIR"), "/examples/sprite/shader.vert").into(),
         ShaderKind::Vertex,
         SourceLanguage::GLSL,
         "main",
     ).precompile().unwrap();
 
-    static ref FRAGMENT: SpirvShader = PathBufShaderInfo::new(
+    static ref FRAGMENT: SpirvShader = SourceShaderInfo::new(
+        include_str!("shader.frag"),
         concat!(env!("CARGO_MANIFEST_DIR"), "/examples/sprite/shader.frag").into(),
         ShaderKind::Fragment,
         SourceLanguage::GLSL,

--- a/rendy/examples/sprite/main.rs
+++ b/rendy/examples/sprite/main.rs
@@ -18,7 +18,7 @@ use rendy::{
     memory::Dynamic,
     mesh::PosTex,
     resource::{Buffer, BufferInfo, DescriptorSet, DescriptorSetLayout, Escape, Handle},
-    shader::{ShaderKind, SourceLanguage, StaticShaderInfo},
+    shader::{PathBufShaderInfo, ShaderKind, SourceLanguage, SpirvShader},
     texture::{image::ImageTextureConfig, Texture},
     wsi::winit::{EventsLoop, WindowBuilder},
 };
@@ -41,19 +41,19 @@ type Backend = rendy::metal::Backend;
 type Backend = rendy::vulkan::Backend;
 
 lazy_static::lazy_static! {
-    static ref VERTEX: StaticShaderInfo = StaticShaderInfo::new(
-        concat!(env!("CARGO_MANIFEST_DIR"), "/examples/sprite/shader.vert"),
+    static ref VERTEX: SpirvShader = PathBufShaderInfo::new(
+        concat!(env!("CARGO_MANIFEST_DIR"), "/examples/sprite/shader.vert").into(),
         ShaderKind::Vertex,
         SourceLanguage::GLSL,
         "main",
-    );
+    ).precompile().unwrap();
 
-    static ref FRAGMENT: StaticShaderInfo = StaticShaderInfo::new(
-        concat!(env!("CARGO_MANIFEST_DIR"), "/examples/sprite/shader.frag"),
+    static ref FRAGMENT: SpirvShader = PathBufShaderInfo::new(
+        concat!(env!("CARGO_MANIFEST_DIR"), "/examples/sprite/shader.frag").into(),
         ShaderKind::Fragment,
         SourceLanguage::GLSL,
         "main",
-    );
+    ).precompile().unwrap();
 
     static ref SHADERS: rendy::shader::ShaderSetBuilder = rendy::shader::ShaderSetBuilder::default()
         .with_vertex(&*VERTEX).unwrap()

--- a/rendy/examples/triangle/main.rs
+++ b/rendy/examples/triangle/main.rs
@@ -19,7 +19,7 @@ use rendy::{
     memory::Dynamic,
     mesh::PosColor,
     resource::{Buffer, BufferInfo, DescriptorSetLayout, Escape, Handle},
-    shader::{PathBufShaderInfo, ShaderKind, SourceLanguage, SpirvShader},
+    shader::{SourceShaderInfo, ShaderKind, SourceLanguage, SpirvShader},
     wsi::winit::{EventsLoop, WindowBuilder},
 };
 
@@ -39,14 +39,16 @@ type Backend = rendy::metal::Backend;
 type Backend = rendy::vulkan::Backend;
 
 lazy_static::lazy_static! {
-    static ref VERTEX: SpirvShader = PathBufShaderInfo::new(
+    static ref VERTEX: SpirvShader = SourceShaderInfo::new(
+        include_str!("shader.vert"),
         concat!(env!("CARGO_MANIFEST_DIR"), "/examples/triangle/shader.vert").into(),
         ShaderKind::Vertex,
         SourceLanguage::GLSL,
         "main",
     ).precompile().unwrap();
 
-    static ref FRAGMENT: SpirvShader = PathBufShaderInfo::new(
+    static ref FRAGMENT: SpirvShader = SourceShaderInfo::new(
+        include_str!("shader.frag"),
         concat!(env!("CARGO_MANIFEST_DIR"), "/examples/triangle/shader.frag").into(),
         ShaderKind::Fragment,
         SourceLanguage::GLSL,

--- a/shader/src/shaderc.rs
+++ b/shader/src/shaderc.rs
@@ -174,7 +174,7 @@ impl<P, E, S> Shader for SourceCodeShaderInfo<P, E, S>
 pub type SourceShaderInfo = SourceCodeShaderInfo<&'static str, &'static str, &'static str>;
 
 /// DEPRECATED. USE `PathBufShaderInfo` INSTEAD!
-#[deprecated(since = "2.0", note = "StaticShaderInfo will be removed in favor of PathBufShaderInfo soon. Please move to that implementation.")]
+#[deprecated(since = "0.2.1", note = "StaticShaderInfo will be removed in favor of PathBufShaderInfo soon. Please move to that implementation.")]
 pub type StaticShaderInfo = FileShaderInfo<&'static str, &'static str>;
 
 /// Shader info with a PathBuf for the path and static string for entry

--- a/shader/src/shaderc.rs
+++ b/shader/src/shaderc.rs
@@ -12,17 +12,17 @@ macro_rules! vk_make_version {
 
 /// Shader loaded from a source in the filesystem.
 #[derive(Clone, Copy, Debug)]
-pub struct SourceShaderInfo<P, E> {
+pub struct FileShaderInfo<P, E> {
     path: P,
     kind: ShaderKind,
     lang: SourceLanguage,
     entry: E,
 }
 
-impl<P, E> SourceShaderInfo<P, E> {
+impl<P, E> FileShaderInfo<P, E> {
     /// New shader.
     pub fn new(path: P, kind: ShaderKind, lang: SourceLanguage, entry: E) -> Self {
-        SourceShaderInfo {
+        FileShaderInfo {
             path,
             kind,
             lang,
@@ -31,7 +31,7 @@ impl<P, E> SourceShaderInfo<P, E> {
     }
 }
 
-impl<P, E> SourceShaderInfo<P, E>
+impl<P, E> FileShaderInfo<P, E>
 where
     E: AsRef<str>,
 {
@@ -48,7 +48,7 @@ where
     }
 }
 
-impl<P, E> Shader for SourceShaderInfo<P, E>
+impl<P, E> Shader for FileShaderInfo<P, E>
 where
     P: AsRef<std::path::Path> + std::fmt::Debug,
     E: AsRef<str>,
@@ -89,11 +89,96 @@ where
     }
 }
 
+
+/// Shader loaded from a source in the filesystem.
+#[derive(Clone, Copy, Debug)]
+pub struct SourceCodeShaderInfo<P, E, S> {
+    source: S,
+    path: P,
+    kind: ShaderKind,
+    lang: SourceLanguage,
+    entry: E,
+}
+
+impl<P, E, S> SourceCodeShaderInfo<P, E, S> {
+    /// New shader.
+    pub fn new(source: S, path: P, kind: ShaderKind, lang: SourceLanguage, entry: E) -> Self {
+        SourceCodeShaderInfo {
+            source,
+            path,
+            kind,
+            lang,
+            entry,
+        }
+    }
+}
+
+impl<P, E, S> SourceCodeShaderInfo<P, E, S>
+    where
+        E: AsRef<str>,
+{
+    /// Precompile shader source code into Spir-V bytecode.
+    pub fn precompile(&self) -> Result<SpirvShader, failure::Error>
+        where
+            Self: Shader,
+    {
+        Ok(SpirvShader::new(
+            self.spirv()?.into_owned(),
+            stage_from_kind(&self.kind),
+            self.entry.as_ref(),
+        ))
+    }
+}
+
+impl<P, E, S> Shader for SourceCodeShaderInfo<P, E, S>
+    where
+        P: AsRef<std::path::Path> + std::fmt::Debug,
+        E: AsRef<str>,
+        S: AsRef<str> + std::fmt::Debug,
+{
+    fn spirv(&self) -> Result<std::borrow::Cow<'static, [u8]>, failure::Error> {
+        let artifact = shaderc::Compiler::new()
+            .ok_or_else(|| failure::format_err!("Failed to init Shaderc"))?
+            .compile_into_spirv(
+                self.source.as_ref(),
+                self.kind,
+                self.path.as_ref().to_str().ok_or_else(|| {
+                    failure::format_err!("'{:?}' is not valid UTF-8 string", self.path)
+                })?,
+                self.entry.as_ref(),
+                Some({
+                    let mut ops = shaderc::CompileOptions::new()
+                        .ok_or_else(|| failure::format_err!("Failed to init Shaderc"))?;
+                    ops.set_target_env(shaderc::TargetEnv::Vulkan, vk_make_version!(1, 0, 0));
+                    ops.set_source_language(self.lang);
+                    ops.set_generate_debug_info();
+                    ops.set_optimization_level(shaderc::OptimizationLevel::Performance);
+                    ops
+                })
+                    .as_ref(),
+            )?;
+
+        Ok(std::borrow::Cow::Owned(artifact.as_binary_u8().into()))
+    }
+
+    fn entry(&self) -> &str {
+        self.entry.as_ref()
+    }
+
+    fn stage(&self) -> gfx_hal::pso::ShaderStageFlags {
+        stage_from_kind(&self.kind)
+    }
+}
+
 /// Shader info with static data.
-pub type StaticShaderInfo = SourceShaderInfo<&'static str, &'static str>;
+pub type SourceShaderInfo = SourceCodeShaderInfo<&'static str, &'static str, &'static str>;
+
+/// DEPRECATED. USE `PathBufShaderInfo` INSTEAD!
+#[deprecated(since = "2.0", note = "StaticShaderInfo will be removed in favor of PathBufShaderInfo soon. Please move to that implementation.")]
+pub type StaticShaderInfo = FileShaderInfo<&'static str, &'static str>;
 
 /// Shader info with a PathBuf for the path and static string for entry
-pub type PathBufShaderInfo = SourceShaderInfo<std::path::PathBuf, &'static str>;
+pub type PathBufShaderInfo = FileShaderInfo<std::path::PathBuf, &'static str>;
 
 fn stage_from_kind(kind: &ShaderKind) -> gfx_hal::pso::ShaderStageFlags {
     use gfx_hal::pso::ShaderStageFlags;


### PR DESCRIPTION
Deprecates StaticShaderInfo in favor of PathBufShaderInfo. Implements SourceShaderInfo publically which allows for providing raw GLSL source code to pass to shaderc-rs. Adds new example source_shaders for usage. All examples updated for deprecated functionality.

This move soft-deprecates the current StaticShaderInfo which actually wasn't in line with the current implementation; this was supposed to support string shader info to begin with, but instead just provided a path. This instead deprecates that access, and pushes all implementations to PathBufShaderInfo, which enforces a proper PathBuf be supplied (this will actually fix support for non-english user filesystems better).

Then, this changes the current SourceShaderInfo to FileShaderInfo, to better reflect its implementation. Finally, a new implementation SourceCodeShaderInfo is made, which loads from source, and then is aliased as SourceShaderInfo for public consumption.

Closes #136
Closes #140 