### PR TITLE
Don't panic when freeing resources if already panicking.

### DIFF
--- a/memory/src/allocator/dynamic.rs
+++ b/memory/src/allocator/dynamic.rs
@@ -2,6 +2,7 @@ use std::{
     collections::{BTreeSet, HashMap},
     ops::Range,
     ptr::NonNull,
+    thread,
 };
 
 use {
@@ -473,8 +474,16 @@ where
 
     /// Perform full cleanup of the memory allocated.
     pub fn dispose(self) {
-        for (index, size) in self.sizes {
-            assert_eq!(size.chunks.len(), 0, "SizeEntry({}) is still used", index);
+        if !thread::panicking() {
+            for (index, size) in self.sizes {
+                assert_eq!(size.chunks.len(), 0, "SizeEntry({}) is still used", index);
+            }
+        } else {
+            for (index, size) in self.sizes {
+                if size.chunks.len() != 0 {
+                    log::error!("Memory leak: SizeEntry({}) is still used", index);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
When using `rendy` in a test application, and the application panics, sometimes there are resources that are still held when `DynamicAllocator::dispose(self)` is called, causing an illegal instruction (segfault) on Windows.

This PR prevents a double panic, though I don't understand `rendy` enough to tell how to free up the resources before the allocator.