### PR TITLE
Replace erroneous assert with force limit

### DIFF
--- a/memory/src/allocator/dynamic.rs
+++ b/memory/src/allocator/dynamic.rs
@@ -548,8 +548,7 @@ where
     }
 
     fn from_block(block_size: u64, chunk_block: DynamicBlock<B>) -> Self {
-        let blocks = chunk_block.size() / block_size;
-        debug_assert!(blocks <= MAX_BLOCKS_PER_CHUNK as u64);
+        let blocks = (chunk_block.size() / block_size).min(MAX_BLOCKS_PER_CHUNK as u64);
 
         let high_bit = 1 << (blocks - 1);
 


### PR DESCRIPTION
Since allocated block **can** be bigger than requested this assert is not actually correct.