### PR TITLE
Fix another rendy-memory assert

### DIFF
--- a/memory/src/allocator/dynamic.rs
+++ b/memory/src/allocator/dynamic.rs
@@ -588,8 +588,7 @@ where
 
     /// Check if there are free blocks.
     fn is_unused(&self, block_size: u64) -> bool {
-        let blocks = (self.size() / block_size) as u32;
-        debug_assert!(blocks <= MAX_BLOCKS_PER_CHUNK);
+        let blocks = (self.size() / block_size).min(MAX_BLOCKS_PER_CHUNK as u64);
 
         let high_bit = 1 << (blocks - 1);
         let mask = (high_bit - 1) | high_bit;


### PR DESCRIPTION
I hit another very similar looking assert.
Please be aware that I don't properly understand this and I just cargo-culted your library so that my program works. :P

I also changed `blocks` from a u32 to a u64, because it looks like high_bit is supposed to get shifted all the way. But this didn't affect my program either way.

Also also, it looks like there are even more similar asserts lying around :eyes: But I have no idea if they are correct or not.