### PR TITLE
Release rendy-memory 0.2.1

### DIFF
--- a/memory/Cargo.toml
+++ b/memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rendy-memory"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["omni-viral <scareaangel@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/amethyst/rendy"


### PR DESCRIPTION
The rendy-memory changes look non-breaking to me.
Do these releases go into the master branch?

This release is so I can get the assert fixes for my project.