### PR TITLE
Add dyn RenderGroup API to subpass builder

### DIFF
--- a/graph/src/graph/mod.rs
+++ b/graph/src/graph/mod.rs
@@ -100,7 +100,11 @@ impl<B: Backend> GraphContext<B> {
             })
             .collect::<Result<_, _>>()?;
 
-        Ok(Self { buffers, images, frames_in_flight })
+        Ok(Self {
+            buffers,
+            images,
+            frames_in_flight,
+        })
     }
 
     /// Get reference to transient image by id.
@@ -258,7 +262,8 @@ where
 }
 
 /// Build graph from nodes and resource.
-#[derive(Debug)]
+#[derive(derivative::Derivative)]
+#[derivative(Debug(bound = ""))]
 pub struct GraphBuilder<B: Backend, T: ?Sized> {
     nodes: Vec<Box<dyn NodeBuilder<B, T>>>,
     buffers: Vec<BufferInfo>,

--- a/graph/src/node/render/pass.rs
+++ b/graph/src/node/render/pass.rs
@@ -68,6 +68,18 @@ where
         self
     }
 
+    /// Add render group of dynamic type to this subpass.
+    pub fn add_dyn_group(&mut self, group: Box<dyn RenderGroupBuilder<B, T>>) -> &mut Self {
+        self.groups.push(group);
+        self
+    }
+
+    /// Add render group of dynamic type to this subpass.
+    pub fn with_dyn_group(mut self, group: Box<dyn RenderGroupBuilder<B, T>>) -> Self {
+        self.add_dyn_group(group);
+        self
+    }
+
     /// Add input attachment to the subpass.
     pub fn add_input(&mut self, input: ImageId) -> &mut Self {
         self.inputs.push(Either::Left(input));

--- a/mesh/src/mesh.rs
+++ b/mesh/src/mesh.rs
@@ -410,17 +410,13 @@ where
     {
         let vertex_iter = self.get_vertex_iter(formats)?;
         match self.index_buffer.as_ref() {
-            Some(index_buffer) => {
-                unsafe {
-                    encoder.bind_index_buffer(index_buffer.buffer.raw(), 0, index_buffer.index_type);
-                    encoder.bind_vertex_buffers(first_binding, vertex_iter);
-                }
-            }
-            None => {
-                unsafe {
-                    encoder.bind_vertex_buffers(first_binding, vertex_iter);
-                }
-            }
+            Some(index_buffer) => unsafe {
+                encoder.bind_index_buffer(index_buffer.buffer.raw(), 0, index_buffer.index_type);
+                encoder.bind_vertex_buffers(first_binding, vertex_iter);
+            },
+            None => unsafe {
+                encoder.bind_vertex_buffers(first_binding, vertex_iter);
+            },
         }
 
         Ok(self.len)
@@ -438,7 +434,11 @@ where
         unsafe {
             match self.index_buffer.as_ref() {
                 Some(index_buffer) => {
-                    encoder.bind_index_buffer(index_buffer.buffer.raw(), 0, index_buffer.index_type);
+                    encoder.bind_index_buffer(
+                        index_buffer.buffer.raw(),
+                        0,
+                        index_buffer.index_type,
+                    );
                     encoder.bind_vertex_buffers(first_binding, vertex_iter);
                     encoder.draw_indexed(0..self.len, 0, instance_range);
                 }
@@ -460,8 +460,10 @@ where
     not_found, in_formats
 )]
 pub struct Incompatible {
-    not_found: VertexFormat,
-    in_formats: Vec<VertexFormat>,
+    /// Format that was queried but was not found
+    pub not_found: VertexFormat,
+    /// List of formats that were available at query time
+    pub in_formats: Vec<VertexFormat>,
 }
 
 /// Helper function to find buffer with compatible format.

--- a/wsi/src/lib.rs
+++ b/wsi/src/lib.rs
@@ -295,7 +295,7 @@ unsafe fn create_swapchain<B: Backend>(
 
     assert!(
         capabilities.usage.contains(usage),
-        "Surface supports {:?}, but {:?} was requested"
+        "Surface supports {:?}, but {:?} was requested", capabilities.usage, usage
     );
 
     let extent = capabilities.current_extent.unwrap_or(suggest_extent);


### PR DESCRIPTION
This change allows explicitly passing boxed rendergroups to the pass. This doesn't add any cost, as concrete types were translated to boxes anyway.
This is required for easier implementation of ergonomic-friendly abstraction over rendergarph builder.

Additionaly fixed error reporting problems that I ran into when working on that.