### PR TITLE
Removed uses of FnvHashMap for Rust standard library's HashMap.

### DIFF
--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -15,6 +15,5 @@ profiler = ["thread_profiler/thread_profiler"]
 
 [dependencies]
 gfx-hal = "0.2"
-fnv = "1.0"
 log = "0.4"
 thread_profiler = "0.3"

--- a/chain/src/chain/mod.rs
+++ b/chain/src/chain/mod.rs
@@ -4,6 +4,8 @@
 //! This information allows to derive synchronization required.
 //!
 
+use std::collections::HashMap;
+
 mod link;
 
 use std::ops::BitOr;
@@ -91,7 +93,7 @@ where
 }
 
 /// Type alias for map of chains by id for buffers.
-pub(crate) type BufferChains = fnv::FnvHashMap<Id, Chain<Buffer>>;
+pub(crate) type BufferChains = HashMap<Id, Chain<Buffer>>;
 
 /// Type alias for map of chains by id for images.
-pub(crate) type ImageChains = fnv::FnvHashMap<Id, Chain<Image>>;
+pub(crate) type ImageChains = HashMap<Id, Chain<Image>>;

--- a/chain/src/collect.rs
+++ b/chain/src/collect.rs
@@ -1,4 +1,6 @@
 use std::cmp::max;
+use std::collections::HashMap;
+use std::collections::hash_map::RandomState;
 use std::hash::Hash;
 use std::ops::Range;
 
@@ -179,13 +181,13 @@ fn fill<T: Default>(num: usize) -> Vec<T> {
 }
 
 struct LookupBuilder<I: Hash + Eq + Copy> {
-    forward: fnv::FnvHashMap<I, usize>,
+    forward: HashMap<I, usize>,
     backward: Vec<I>,
 }
 impl<I: Hash + Eq + Copy> LookupBuilder<I> {
     fn new() -> LookupBuilder<I> {
         LookupBuilder {
-            forward: fnv::FnvHashMap::default(),
+            forward: HashMap::default(),
             backward: Vec::new(),
         }
     }
@@ -215,7 +217,9 @@ where
     let mut buffers = LookupBuilder::new();
     let mut images = LookupBuilder::new();
 
-    let mut family_full = fnv::FnvHashMap::default();
+    let s = RandomState::new();
+    let mut family_full = HashMap::with_hasher(s);
+
     for node in nodes {
         let family = node.family;
         if !family_full.contains_key(&family) {
@@ -268,8 +272,8 @@ where
     )
 }
 
-fn reify_chain<R: Resource>(ids: &[Id], vec: Vec<ChainData<R>>) -> fnv::FnvHashMap<Id, Chain<R>> {
-    let mut map = fnv::FnvHashMap::with_capacity_and_hasher(vec.len(), Default::default());
+fn reify_chain<R: Resource>(ids: &[Id], vec: Vec<ChainData<R>>) -> HashMap<Id, Chain<R>> {
+    let mut map = HashMap::with_capacity_and_hasher(vec.len(), Default::default());
     for (chain, &i) in vec.into_iter().zip(ids) {
         map.insert(i, chain.chain);
     }

--- a/chain/src/schedule/mod.rs
+++ b/chain/src/schedule/mod.rs
@@ -12,6 +12,7 @@ mod family;
 mod queue;
 mod submission;
 
+use std::collections::HashMap;
 use std::ops::{Index, IndexMut};
 
 pub use self::{
@@ -23,7 +24,7 @@ pub use self::{
 /// Whole passes schedule.
 #[derive(Clone, Debug)]
 pub struct Schedule<S> {
-    map: fnv::FnvHashMap<gfx_hal::queue::QueueFamilyId, Family<S>>,
+    map: HashMap<gfx_hal::queue::QueueFamilyId, Family<S>>,
     ordered: Vec<SubmissionId>,
 }
 
@@ -31,7 +32,7 @@ impl<S> Schedule<S> {
     /// Create new empty `Schedule`
     pub fn new() -> Self {
         Schedule {
-            map: fnv::FnvHashMap::default(),
+            map: HashMap::default(),
             ordered: Vec::new(),
         }
     }

--- a/chain/src/schedule/submission.rs
+++ b/chain/src/schedule/submission.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use super::queue::QueueId;
 use crate::Id;
 
@@ -38,8 +39,8 @@ impl SubmissionId {
 pub struct Submission<S> {
     node: usize,
     id: SubmissionId,
-    buffer_links: fnv::FnvHashMap<Id, usize>,
-    image_links: fnv::FnvHashMap<Id, usize>,
+    buffer_links: HashMap<Id, usize>,
+    image_links: HashMap<Id, usize>,
     wait_factor: usize,
     submit_order: usize,
     sync: S,
@@ -101,8 +102,8 @@ impl<S> Submission<S> {
     ) -> Self {
         Submission {
             node,
-            buffer_links: fnv::FnvHashMap::default(),
-            image_links: fnv::FnvHashMap::default(),
+            buffer_links: HashMap::default(),
+            image_links: HashMap::default(),
             id,
             wait_factor,
             submit_order,

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -31,7 +31,6 @@ gfx-backend-dx12 = { version = "0.2", optional = true }
 gfx-backend-metal = { version = "0.2", optional = true }
 gfx-backend-vulkan = { version = "0.2", optional = true }
 derivative = "1.0"
-fnv = "1.0"
 lazy_static = "1.0"
 log = "0.4"
 parking_lot = "0.7"

--- a/util/src/types/vertex.rs
+++ b/util/src/types/vertex.rs
@@ -4,6 +4,7 @@ use derivative::Derivative;
 use gfx_hal::format::Format;
 use std::cmp::Ordering;
 use std::{borrow::Cow, fmt::Debug};
+use std::collections::HashMap;
 
 /// Trait for vertex attributes to implement
 pub trait AsAttribute: Debug + PartialEq + PartialOrd + Copy + Send + Sync + 'static {
@@ -18,7 +19,7 @@ pub trait AsAttribute: Debug + PartialEq + PartialOrd + Copy + Send + Sync + 'st
 pub struct AttrUuid(u16);
 
 lazy_static::lazy_static! {
-    static ref UUID_MAP: parking_lot::RwLock<fnv::FnvHashMap<(Cow<'static, str>, u8, Format), AttrUuid>> =
+    static ref UUID_MAP: parking_lot::RwLock<HashMap<(Cow<'static, str>, u8, Format), AttrUuid>> =
         Default::default();
 }
 


### PR DESCRIPTION
Closes #160.