### PR TITLE
fix potentially unsound Factory::drop

### DIFF
--- a/factory/src/factory.rs
+++ b/factory/src/factory.rs
@@ -110,7 +110,10 @@ where
 {
     fn drop(&mut self) {
         log::debug!("Dropping factory");
-        let _ = self.wait_idle();
+        match self.wait_idle() {
+            Err(HostExecutionError::DeviceLost) | Ok(()) => (),
+            Err(err) => panic!("{}", err),
+        }
 
         unsafe {
             // Device is idle.


### PR DESCRIPTION
As far as I know calling dispose requires unique access on a device.  This is guaranteed by calling `device.wait_idle()`. As we previously discarded the result of this call, it may have silently failed. This allowed us to cause UB by disposing currently used resources later on.

I am currently not that knowledgeable about both vulkan and rendy, so please correct me if anything I said was wrong.