### PR TITLE
Optional support for using winit 0.20. Opt-in using feature "winit-20".

### DIFF
--- a/factory/src/factory.rs
+++ b/factory/src/factory.rs
@@ -1154,7 +1154,7 @@ rendy_wsi::with_winit! {
         B: Backend,
     {
         /// Create rendering surface from window.
-        pub fn create_surface(&mut self, window: &rendy_wsi::winit::Window) -> Surface<B> {
+        pub fn create_surface(&mut self, window: &rendy_wsi::WinitWindow) -> Surface<B> {
             profile_scope!("create_surface");
             Surface::new(&self.instance, window)
         }

--- a/rendy/Cargo.toml
+++ b/rendy/Cargo.toml
@@ -13,6 +13,7 @@ readme = "../README.md"
 
 [features]
 serde-1 = ["rendy-factory/serde-1", "rendy-mesh/serde-1", "rendy-texture/serde-1", "rendy-shader/serde-1", "rendy-util/serde-1"]
+winit-20 = ["rendy-wsi/winit-20"]
 
 # Rendy subcrates
 command = ["rendy-command"]

--- a/wsi/Cargo.toml
+++ b/wsi/Cargo.toml
@@ -16,6 +16,7 @@ dx12 = ["rendy-util/dx12"]
 metal = ["rendy-util/metal"]
 vulkan = ["rendy-util/vulkan"]
 no-slow-safety-checks = ["rendy-util/no-slow-safety-checks"]
+winit = ["winit-19"]
 
 [dependencies]
 rendy-memory = { version = "0.3.0", path = "../memory" }
@@ -28,4 +29,6 @@ failure = "0.1"
 log = "0.4"
 relevant = { version = "0.4", features = ["log", "backtrace"] }
 smallvec = "0.6"
-winit = { version = "0.19", optional = true }
+
+winit-19 = { version = ">= 0.16, <= 0.19", package = "winit", optional = true }
+winit-20 = { version = "0.20.0-alpha2", package = "winit", optional = true }

--- a/wsi/src/lib.rs
+++ b/wsi/src/lib.rs
@@ -21,18 +21,29 @@ use {
     },
 };
 
-#[cfg(feature = "winit")]
+#[cfg(any(feature = "winit-19", feature = "winit-20"))]
 use rendy_util::rendy_backend_match;
 
-#[cfg(feature = "winit")]
-pub use winit;
+#[cfg(all(feature = "winit-19", not(feature = "winit-20")))]
+pub use winit_19 as winit;
+
+#[cfg(all(feature = "winit-19", not(feature = "winit-20")))]
+pub use winit::Window as WinitWindow;
+
+#[cfg(all(feature = "winit-19", feature = "winit-20"))]
+pub use winit_20 as winit;
+
+#[cfg(all(feature = "winit-19", feature = "winit-20"))]
+pub use winit::window::Window as WinitWindow;
+
+
 
 rendy_with_empty_backend! {
     mod gfx_backend_empty {
-        #[cfg(feature = "winit")]
+        #[cfg(any(feature = "winit-19", feature = "winit-20"))]
         pub(super) fn create_surface(
             _instance: &rendy_util::empty::Instance,
-            _window: &winit::Window,
+            _window: &super::WinitWindow,
         ) -> rendy_util::empty::Surface {
             rendy_util::empty::Surface
         }
@@ -41,10 +52,10 @@ rendy_with_empty_backend! {
 
 rendy_with_dx12_backend! {
     mod gfx_backend_dx12 {
-        #[cfg(feature = "winit")]
+        #[cfg(any(feature = "winit-19", feature = "winit-20"))]
         pub(super) fn create_surface(
             instance: &rendy_util::dx12::Instance,
-            window: &winit::Window,
+            window: &super::WinitWindow,
         ) -> <rendy_util::dx12::Backend as gfx_hal::Backend>::Surface {
             instance.create_surface(window)
         }
@@ -53,10 +64,10 @@ rendy_with_dx12_backend! {
 
 rendy_with_metal_backend! {
     mod gfx_backend_metal {
-        #[cfg(feature = "winit")]
+        #[cfg(any(feature = "winit-19", feature = "winit-20"))]
         pub(super) fn create_surface(
             instance: &rendy_util::metal::Instance,
-            window: &winit::Window,
+            window: &super::WinitWindow,
         ) -> <rendy_util::metal::Backend as gfx_hal::Backend>::Surface {
             instance.create_surface(window)
         }
@@ -65,19 +76,19 @@ rendy_with_metal_backend! {
 
 rendy_with_vulkan_backend! {
     mod gfx_backend_vulkan {
-        #[cfg(feature = "winit")]
+        #[cfg(any(feature = "winit-19", feature = "winit-20"))]
         pub(super) fn create_surface(
             instance: &rendy_util::vulkan::Instance,
-            window: &winit::Window,
+            window: &super::WinitWindow,
         ) -> <rendy_util::vulkan::Backend as gfx_hal::Backend>::Surface {
             instance.create_surface(window)
         }
     }
 }
 
-#[cfg(feature = "winit")]
+#[cfg(any(feature = "winit-19", feature = "winit-20"))]
 #[allow(unused)]
-fn create_surface<B: Backend>(instance: &Instance<B>, window: &winit::Window) -> B::Surface {
+fn create_surface<B: Backend>(instance: &Instance<B>, window: &WinitWindow) -> B::Surface {
     use rendy_util::identical_cast;
 
     // We perform identical type transmute.
@@ -121,8 +132,8 @@ where
     B: Backend,
 {
     /// Create surface for the window.
-    #[cfg(feature = "winit")]
-    pub fn new(instance: &Instance<B>, window: &winit::Window) -> Self {
+    #[cfg(any(feature = "winit-19", feature = "winit-20"))]
+    pub fn new(instance: &Instance<B>, window: &WinitWindow) -> Self {
         let raw = create_surface::<B>(instance, &window);
         Surface {
             raw,
@@ -552,7 +563,7 @@ where
 }
 
 /// Resolve into input AST if winit support is enabled.
-#[cfg(feature = "winit")]
+#[cfg(any(feature = "winit-19", feature = "winit-20"))]
 #[macro_export]
 macro_rules! with_winit {
     ($($t:tt)*) => { $($t)* };


### PR DESCRIPTION
This would allow optional usage of winit 0.20.0. Examples and default build behavior would continue to use earlier winit versions.