### PR TITLE
Update shaderc version to 0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,17 @@ matrix:
     - env: MACOSX_DEPLOYMENT_TARGET=10.9
       os: osx
       osx_image: xcode10.2
-      install: travis_wait 30 cargo build --verbose
+      # We need travis_wait here to ensure the build doesn't timeout due to
+      # shader compilation
+      script: travis_wait 30 make
 
     # iPhoneOS 64bit
     - env: TARGET=aarch64-apple-ios
       os: osx
       osx_image: xcode10.2
-      install: travis_wait 30 cargo build --verbose
+      # We need travis_wait here to ensure the build doesn't timeout due to
+      # shader compilation
+      script: travis_wait 30 make
 
     # Windows 64bit
     - os: windows
@@ -37,6 +41,9 @@ before_install:
   - if [[ $TRAVIS_OS_NAME == "windows" ]]; then choco install make; choco install ninja; choco install python; fi
   - rustup self update
   - if [[ ! -z "$TARGET" ]]; then rustup target add $TARGET; fi
+
+# Set the default install command to nothing as we build during the script stage
+install:
 
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,13 @@ matrix:
     - env: MACOSX_DEPLOYMENT_TARGET=10.9
       os: osx
       osx_image: xcode10.2
+      install: travis_wait 30 cargo build --verbose
 
     # iPhoneOS 64bit
     - env: TARGET=aarch64-apple-ios
       os: osx
       osx_image: xcode10.2
+      install: travis_wait 30 cargo build --verbose
 
     # Windows 64bit
     - os: windows

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,15 +14,16 @@ matrix:
     # macOS 64bit
     - env: MACOSX_DEPLOYMENT_TARGET=10.9
       os: osx
-      osx_image: xcode9
+      osx_image: xcode10.2
 
     # iPhoneOS 64bit
     - env: TARGET=aarch64-apple-ios
       os: osx
-      osx_image: xcode9
+      osx_image: xcode10.2
 
     # Windows 64bit
     - os: windows
+      env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
 
 branches:
   only:
@@ -31,7 +32,7 @@ branches:
     - master
 
 before_install:
-  - if [[ $TRAVIS_OS_NAME == "windows" ]]; then choco install make; choco install ninja; fi
+  - if [[ $TRAVIS_OS_NAME == "windows" ]]; then choco install make; choco install ninja; choco install python; fi
   - rustup self update
   - if [[ ! -z "$TARGET" ]]; then rustup target add $TARGET; fi
 

--- a/factory/src/factory.rs
+++ b/factory/src/factory.rs
@@ -9,10 +9,7 @@ use {
         memory::{self, Heaps, MemoryUsage, TotalMemoryUtilization, Write},
         resource::*,
         upload::{BufferState, ImageState, ImageStateOrLayout, Uploader},
-        util::{
-            identical_cast, rendy_backend_match, rendy_with_slow_safety_checks, Device, DeviceId,
-            Instance,
-        },
+        util::{rendy_backend_match, rendy_with_slow_safety_checks, Device, DeviceId, Instance},
         wsi::{Surface, Target},
     },
     gfx_hal::{
@@ -1030,7 +1027,7 @@ where
     rendy_backend_match!(B as backend => {
         profile_scope!(concat!("init_factory"));
         let instance = backend::Instance::create("Rendy", 1);
-        Ok(identical_cast(init_with_instance(instance, config)?))
+        Ok(crate::util::identical_cast(init_with_instance(instance, config)?))
     });
 }
 

--- a/shader/Cargo.toml
+++ b/shader/Cargo.toml
@@ -23,7 +23,7 @@ failure = "0.1"
 gfx-hal = "0.3"
 rendy-factory = { version = "0.4.0", path = "../factory" }
 rendy-util = { version = "0.4.0", path = "../util" }
-shaderc = { version = "0.5", optional = true }
+shaderc = { version = "0.6", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_bytes = { version = "0.11", optional = true }
 spirv-reflect = { version = "0.2.1", optional = true }


### PR DESCRIPTION
This update enables shaderc to choose either shared or static versions
of the SPIRV-Tools, depending on what is installed on the system.

This is a minor update because Python2 is no longer supported ([relevant commit]).

[relevant commit]:
https://github.com/google/shaderc-rs/commit/4689e504ef62a05b8096356e3ad1b025b12283d4