### PR TITLE
Removed size check, add x11 dependency for gfx-backend-vulkan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ ifeq ($(OS),Windows_NT)
 else
 	UNAME_S:=$(shell uname -s)
 	ifeq ($(UNAME_S),Linux)
-		RENDY_BACKEND=vulkan
+		RENDY_BACKEND=vulkan-x11
 	endif
 	ifeq ($(UNAME_S),Darwin)
 		RENDY_BACKEND=metal

--- a/rendy/Cargo.toml
+++ b/rendy/Cargo.toml
@@ -32,6 +32,7 @@ empty = ["rendy-util/gfx-backend-empty"]
 dx12 = ["rendy-util/gfx-backend-dx12"]
 metal = ["rendy-util/gfx-backend-metal"]
 vulkan = ["rendy-util/gfx-backend-vulkan"]
+vulkan-x11 = ["vulkan", "rendy-util/vulkan-x11"]
 no-slow-safety-checks = ["rendy-util/no-slow-safety-checks"]
 profiler = ["thread_profiler/thread_profiler"]
 

--- a/shader/src/lib.rs
+++ b/shader/src/lib.rs
@@ -70,7 +70,6 @@ impl SpirvShader {
     /// Create Spir-V shader from bytes.
     pub fn new(spirv: Vec<u32>, stage: ShaderStageFlags, entrypoint: &str) -> Self {
         assert!(!spirv.is_empty());
-        assert_eq!(spirv.len() % 4, 0);
         Self {
             spirv,
             stage,

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -29,7 +29,7 @@ gfx-hal = "0.3"
 gfx-backend-empty = { version = "0.3", features = ["winit"], optional = true }
 gfx-backend-dx12 = { version = "0.3", features = ["winit"], optional = true }
 gfx-backend-metal = { version = "0.3", features = ["winit"], optional = true }
-gfx-backend-vulkan = { version = "0.3", features = ["winit"], optional = true }
+gfx-backend-vulkan = { version = "0.3", features = ["winit", "x11"], optional = true }
 derivative = "1.0"
 lazy_static = "1.0"
 log = "0.4"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -22,6 +22,7 @@ empty = ["gfx-backend-empty"]
 dx12 = ["gfx-backend-dx12"]
 metal = ["gfx-backend-metal"]
 vulkan = ["gfx-backend-vulkan"]
+vulkan-x11 = ["gfx-backend-vulkan/x11"]
 no-slow-safety-checks = []
 
 [dependencies]
@@ -29,7 +30,7 @@ gfx-hal = "0.3"
 gfx-backend-empty = { version = "0.3", features = ["winit"], optional = true }
 gfx-backend-dx12 = { version = "0.3", features = ["winit"], optional = true }
 gfx-backend-metal = { version = "0.3", features = ["winit"], optional = true }
-gfx-backend-vulkan = { version = "0.3", features = ["winit", "x11"], optional = true }
+gfx-backend-vulkan = { version = "0.3", features = ["winit"], optional = true }
 derivative = "1.0"
 lazy_static = "1.0"
 log = "0.4"


### PR DESCRIPTION
Tried to run the examples in a x11-vulkan setup, and found that the update to gfx-rs 0.3 now needs an explicit "x11" feature. 
Also, since the change of the `spirv` parameter from `Vec<u8>` to `Vec<u32>` in merge (#185) the size check is not correct.