### PR TITLE
changes for amethyst shadow mapping

### DIFF
--- a/chain/src/collect.rs
+++ b/chain/src/collect.rs
@@ -1,6 +1,6 @@
 use std::cmp::max;
-use std::collections::HashMap;
 use std::collections::hash_map::RandomState;
+use std::collections::HashMap;
 use std::hash::Hash;
 use std::ops::Range;
 

--- a/chain/src/schedule/submission.rs
+++ b/chain/src/schedule/submission.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
 use super::queue::QueueId;
 use crate::Id;
+use std::collections::HashMap;
 
 /// Submission id.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]

--- a/command/src/buffer/encoder.rs
+++ b/command/src/buffer/encoder.rs
@@ -229,12 +229,7 @@ where
         dependencies: gfx_hal::memory::Dependencies,
         barriers: impl IntoIterator<Item = gfx_hal::memory::Barrier<'b, B>>,
     ) {
-        gfx_hal::command::CommandBuffer::pipeline_barrier(
-            self.raw,
-            stages,
-            dependencies,
-            barriers,
-        )
+        gfx_hal::command::CommandBuffer::pipeline_barrier(self.raw, stages, dependencies, barriers)
     }
 
     /// Push graphics constants.

--- a/command/src/family/mod.rs
+++ b/command/src/family/mod.rs
@@ -79,7 +79,8 @@ where
                 let pos = queue_groups.iter().position(|qg| qg.family.0 == id.index);
                 let group = queue_groups.swap_remove(pos.unwrap());
                 assert_eq!(group.queues.len(), count);
-                group.queues
+                group
+                    .queues
                     .into_iter()
                     .enumerate()
                     .map(|(index, queue)| Queue::new(queue, QueueId { family: id, index }))
@@ -221,6 +222,19 @@ where
     /// Get id -> index mapping.
     pub fn indices(&self) -> &[usize] {
         &self.families_indices
+    }
+
+    /// Find family id matching predicate
+    pub fn find<F>(&self, predicate: F) -> Option<FamilyId>
+    where
+        F: FnMut(&&Family<B>) -> bool,
+    {
+        self.families.iter().find(predicate).map(Family::id)
+    }
+
+    /// Get first matching family id with specified capability
+    pub fn with_capability<C: Capability>(&self) -> Option<FamilyId> {
+        self.find(|family| Supports::<C>::supports(&family.capability()).is_some())
     }
 }
 

--- a/command/src/fence.rs
+++ b/command/src/fence.rs
@@ -3,7 +3,7 @@ use {
         family::QueueId,
         util::{device_owned, Device, DeviceId},
     },
-    gfx_hal::{Backend, device::Device as _},
+    gfx_hal::{device::Device as _, Backend},
 };
 
 /// Queue epoch is the point in particluar queue timeline when fence is submitted.

--- a/command/src/pool.rs
+++ b/command/src/pool.rs
@@ -2,7 +2,7 @@
 
 use {
     crate::{buffer::*, capability::*, family::FamilyId, util::Device},
-    gfx_hal::{Backend, device::Device as _},
+    gfx_hal::{device::Device as _, Backend},
 };
 
 /// Simple pool wrapper.

--- a/descriptor/src/ranges.rs
+++ b/descriptor/src/ranges.rs
@@ -74,7 +74,7 @@ impl DescriptorRanges {
     /// Calculate ranges from bindings, specified with an iterator.
     pub fn from_binding_iter<I>(bindings: I) -> Self
     where
-        I: Iterator<Item = DescriptorSetLayoutBinding>
+        I: Iterator<Item = DescriptorSetLayoutBinding>,
     {
         let mut descs = Self::zero();
 

--- a/factory/src/blitter.rs
+++ b/factory/src/blitter.rs
@@ -137,14 +137,21 @@ impl From<BlitRegion> for gfx_hal::command::ImageBlit {
 /// A region and image states for one image in a blit.
 #[derive(Debug, Clone)]
 pub struct BlitImageState {
-    subresource: gfx_hal::image::SubresourceLayers,
-    bounds: Range<gfx_hal::image::Offset>,
-    last_stage: gfx_hal::pso::PipelineStage,
-    last_access: gfx_hal::image::Access,
-    last_layout: gfx_hal::image::Layout,
-    next_stage: gfx_hal::pso::PipelineStage,
-    next_access: gfx_hal::image::Access,
-    next_layout: gfx_hal::image::Layout,
+    /// Subresource to use for blit
+    pub subresource: gfx_hal::image::SubresourceLayers,
+    pub bounds: Range<gfx_hal::image::Offset>,
+    /// Last image stage before blit
+    pub last_stage: gfx_hal::pso::PipelineStage,
+    /// Last image access before blit
+    pub last_access: gfx_hal::image::Access,
+    /// Last image layout before blit
+    pub last_layout: gfx_hal::image::Layout,
+    /// Image stage after blit
+    pub next_stage: gfx_hal::pso::PipelineStage,
+    /// Image access after blit
+    pub next_access: gfx_hal::image::Access,
+    /// Image layout after blit
+    pub next_layout: gfx_hal::image::Layout,
 }
 
 impl<B> Blitter<B>

--- a/factory/src/blitter.rs
+++ b/factory/src/blitter.rs
@@ -307,8 +307,7 @@ pub unsafe fn blit_image<B, C, L>(
     dst_image: &Handle<Image<B>>,
     filter: gfx_hal::image::Filter,
     regions: impl IntoIterator<Item = BlitRegion>,
-)
-where
+) where
     B: gfx_hal::Backend,
     C: Supports<Graphics>,
     L: Level,

--- a/factory/src/blitter.rs
+++ b/factory/src/blitter.rs
@@ -139,6 +139,7 @@ impl From<BlitRegion> for gfx_hal::command::ImageBlit {
 pub struct BlitImageState {
     /// Subresource to use for blit
     pub subresource: gfx_hal::image::SubresourceLayers,
+    /// Image offset range to use for blit
     pub bounds: Range<gfx_hal::image::Offset>,
     /// Last image stage before blit
     pub last_stage: gfx_hal::pso::PipelineStage,

--- a/graph/src/graph/mod.rs
+++ b/graph/src/graph/mod.rs
@@ -338,9 +338,12 @@ where
 
     /// Add node to the graph.
     pub fn add_node<N: NodeBuilder<B, T> + 'static>(&mut self, builder: N) -> NodeId {
-        profile_scope!("add_node");
+        self.add_dyn_node(Box::new(builder))
+    }
 
-        self.nodes.push(Box::new(builder));
+    /// Add boxed node to the graph.
+    pub fn add_dyn_node(&mut self, builder: Box<dyn NodeBuilder<B, T> + 'static>) -> NodeId {
+        self.nodes.push(builder);
         NodeId(self.nodes.len() - 1)
     }
 

--- a/graph/src/graph/mod.rs
+++ b/graph/src/graph/mod.rs
@@ -5,8 +5,13 @@ use {
         factory::Factory,
         frame::{Fences, Frame, Frames},
         memory::Data,
-        node::{BufferBarrier, DynNode, ImageBarrier, NodeBuffer, NodeBuilder, NodeBuildError, NodeImage},
-        resource::{Buffer, BufferCreationError, BufferInfo, Handle, Image, ImageCreationError, ImageInfo},
+        node::{
+            BufferBarrier, DynNode, ImageBarrier, NodeBuffer, NodeBuildError, NodeBuilder,
+            NodeImage,
+        },
+        resource::{
+            Buffer, BufferCreationError, BufferInfo, Handle, Image, ImageCreationError, ImageInfo,
+        },
         util::{device_owned, DeviceId},
         BufferId, ImageId, NodeId,
     },
@@ -572,7 +577,7 @@ where
     let images = builder.images();
     chain::Node {
         id,
-        family: QueueFamilyId(builder.family(factory, families.as_slice()).unwrap().index),
+        family: QueueFamilyId(builder.family(factory, families).unwrap().index),
         dependencies: builder.dependencies().into_iter().map(|id| id.0).collect(),
         buffers: buffers
             .into_iter()

--- a/graph/src/node/mod.rs
+++ b/graph/src/node/mod.rs
@@ -202,13 +202,7 @@ pub trait NodeDesc<B: Backend, T: ?Sized>: std::fmt::Debug + Sized + 'static {
 
     /// Make node builder.
     fn builder(self) -> DescBuilder<B, T, Self> {
-        DescBuilder {
-            desc: self,
-            buffers: Vec::new(),
-            images: Vec::new(),
-            dependencies: Vec::new(),
-            marker: std::marker::PhantomData,
-        }
+        DescBuilder::new(self)
     }
 
     /// Get set or buffer resources the node uses.
@@ -361,6 +355,16 @@ where
     B: Backend,
     T: ?Sized,
 {
+    /// Create new builder out of desc
+    pub fn new(desc: N) -> Self {
+        DescBuilder {
+            desc,
+            buffers: Vec::new(),
+            images: Vec::new(),
+            dependencies: Vec::new(),
+            marker: std::marker::PhantomData,
+        }
+    }
     /// Add buffer to the node.
     /// This method must be called for each buffer node uses.
     pub fn add_buffer(&mut self, buffer: BufferId) -> &mut Self {

--- a/graph/src/node/present.rs
+++ b/graph/src/node/present.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     command::{
-        CommandBuffer, CommandPool, ExecutableState, Family, FamilyId, Fence, MultiShot,
+        CommandBuffer, CommandPool, ExecutableState, Families, Family, FamilyId, Fence, MultiShot,
         PendingState, Queue, SimultaneousUse, Submission, Submit,
     },
     factory::Factory,
@@ -359,12 +359,9 @@ where
     B: gfx_hal::Backend,
     T: ?Sized,
 {
-    fn family(&self, factory: &mut Factory<B>, families: &[Family<B>]) -> Option<FamilyId> {
+    fn family(&self, factory: &mut Factory<B>, families: &Families<B>) -> Option<FamilyId> {
         // Find correct queue family.
-        families
-            .iter()
-            .find(|family| factory.surface_support(family.id(), &self.surface))
-            .map(Family::id)
+        families.find(|family| factory.surface_support(family.id(), &self.surface))
     }
 
     fn buffers(&self) -> Vec<(BufferId, BufferAccess)> {

--- a/graph/src/node/present.rs
+++ b/graph/src/node/present.rs
@@ -9,8 +9,8 @@ use crate::{
     frame::Frames,
     graph::GraphContext,
     node::{
-        gfx_acquire_barriers, gfx_release_barriers, BufferAccess, DynNode,
-        ImageAccess, NodeBuffer, NodeBuilder, NodeBuildError, NodeImage,
+        gfx_acquire_barriers, gfx_release_barriers, BufferAccess, DynNode, ImageAccess, NodeBuffer,
+        NodeBuildError, NodeBuilder, NodeImage,
     },
     wsi::{Surface, Target},
     BufferId, ImageId, NodeId,
@@ -29,7 +29,11 @@ struct ForImage<B: gfx_hal::Backend> {
 }
 
 impl<B: gfx_hal::Backend> ForImage<B> {
-    unsafe fn dispose(self, factory: &Factory<B>, pool: &mut CommandPool<B, gfx_hal::queue::QueueType>) {
+    unsafe fn dispose(
+        self,
+        factory: &Factory<B>,
+        pool: &mut CommandPool<B, gfx_hal::queue::QueueType>,
+    ) {
         drop(self.submit);
         factory.destroy_semaphore(self.acquire);
         factory.destroy_semaphore(self.release);
@@ -405,7 +409,11 @@ where
             .into();
 
         if !factory.surface_support(family.id(), &self.surface) {
-            log::warn!("Surface {:?} presentation is unsupported by family {:?} bound to the node", self.surface, family);
+            log::warn!(
+                "Surface {:?} presentation is unsupported by family {:?} bound to the node",
+                self.surface,
+                family
+            );
             return Err(NodeBuildError::QueueFamily(family.id()));
         }
 
@@ -419,7 +427,8 @@ where
             )
             .map_err(NodeBuildError::Swapchain)?;
 
-        let mut pool = factory.create_command_pool(family)
+        let mut pool = factory
+            .create_command_pool(family)
             .map_err(NodeBuildError::OutOfMemory)?;
 
         let per_image = create_per_image_data(

--- a/graph/src/node/render/group/simple.rs
+++ b/graph/src/node/render/group/simple.rs
@@ -9,7 +9,7 @@ use {
         },
         resource::{DescriptorSetLayout, Handle},
     },
-    gfx_hal::{Backend, device::Device as _},
+    gfx_hal::{device::Device as _, Backend},
 };
 
 pub use crate::util::types::{Layout, SetLayout};

--- a/memory/src/allocator/dedicated.rs
+++ b/memory/src/allocator/dedicated.rs
@@ -7,7 +7,7 @@ use {
         mapping::{mapped_fitting_range, MappedRange},
         memory::*,
     },
-    gfx_hal::{Backend, device::Device as _},
+    gfx_hal::{device::Device as _, Backend},
 };
 
 /// Memory block allocated from `DedicatedAllocator`

--- a/memory/src/allocator/dynamic.rs
+++ b/memory/src/allocator/dynamic.rs
@@ -13,7 +13,7 @@ use {
         memory::*,
         util::*,
     },
-    gfx_hal::{Backend, device::Device as _},
+    gfx_hal::{device::Device as _, Backend},
     hibitset::{BitSet, BitSetLike as _},
 };
 

--- a/memory/src/allocator/linear.rs
+++ b/memory/src/allocator/linear.rs
@@ -8,7 +8,7 @@ use {
         memory::*,
         util::*,
     },
-    gfx_hal::{Backend, device::Device as _},
+    gfx_hal::{device::Device as _, Backend},
 };
 
 /// Memory block allocated from `LinearAllocator`

--- a/memory/src/mapping/mod.rs
+++ b/memory/src/mapping/mod.rs
@@ -3,7 +3,7 @@ pub(crate) mod write;
 
 use {
     crate::{memory::Memory, util::fits_usize},
-    gfx_hal::{Backend, device::Device as _},
+    gfx_hal::{device::Device as _, Backend},
     std::{ops::Range, ptr::NonNull},
 };
 

--- a/mesh/src/mesh.rs
+++ b/mesh/src/mesh.rs
@@ -254,10 +254,11 @@ impl<'a> MeshBuilder<'a> {
             )
             .map_err(UploadError::Create)?;
 
-        let mut mapped = staging.map(factory, 0..aligned_size)
+        let mut mapped = staging
+            .map(factory, 0..aligned_size)
             .map_err(UploadError::Map)?;
-        let mut writer = unsafe { mapped.write(factory, 0..aligned_size) }
-            .map_err(UploadError::Map)?;
+        let mut writer =
+            unsafe { mapped.write(factory, 0..aligned_size) }.map_err(UploadError::Map)?;
         let staging_slice = unsafe { writer.slice() };
 
         let mut offset = 0usize;
@@ -293,7 +294,8 @@ impl<'a> MeshBuilder<'a> {
                     .create_buffer(
                         BufferInfo {
                             size: indices.len() as _,
-                            usage: gfx_hal::buffer::Usage::INDEX | gfx_hal::buffer::Usage::TRANSFER_DST,
+                            usage: gfx_hal::buffer::Usage::INDEX
+                                | gfx_hal::buffer::Usage::TRANSFER_DST,
                         },
                         Data,
                     )

--- a/rendy/examples/meshes/main.rs
+++ b/rendy/examples/meshes/main.rs
@@ -248,7 +248,11 @@ where
             }
         }
 
-        Ok(MeshRenderPipeline { align, buffer, sets })
+        Ok(MeshRenderPipeline {
+            align,
+            buffer,
+            sets,
+        })
     }
 }
 

--- a/rendy/examples/meshes/main.rs
+++ b/rendy/examples/meshes/main.rs
@@ -17,7 +17,7 @@ use {
         graph::{
             present::PresentNode, render::*, GraphBuilder, GraphContext, NodeBuffer, NodeImage,
         },
-        hal::{self, device::Device as _, adapter::PhysicalDevice as _},
+        hal::{self, adapter::PhysicalDevice as _, device::Device as _},
         memory::Dynamic,
         mesh::{Mesh, Model, PosColorNorm},
         resource::{Buffer, BufferInfo, DescriptorSet, DescriptorSetLayout, Escape, Handle},
@@ -393,9 +393,7 @@ fn main() {
 
     let mut graph_builder = GraphBuilder::<Backend, Scene<Backend>>::new();
 
-    let size = window
-        .inner_size()
-        .to_physical(window.hidpi_factor());
+    let size = window.inner_size().to_physical(window.hidpi_factor());
     let window_kind = hal::image::Kind::D2(size.width as u32, size.height as u32, 1, 1);
     let aspect = size.width / size.height;
 
@@ -519,9 +517,7 @@ fn main() {
         *control_flow = ControlFlow::Poll;
         match event {
             Event::WindowEvent { event, .. } => match event {
-                WindowEvent::CloseRequested => {
-                    *control_flow = ControlFlow::Exit
-                }
+                WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
                 _ => {}
             },
             Event::EventsCleared => {
@@ -549,10 +545,7 @@ fn main() {
                 if elapsed >= std::time::Duration::new(5, 0) || *control_flow == ControlFlow::Exit {
                     let frames = frame - start;
                     let nanos = elapsed.as_secs() * 1_000_000_000 + elapsed.subsec_nanos() as u64;
-                    fpss.push((
-                        frames * 1_000_000_000 / nanos,
-                        from..scene.objects.len(),
-                    ));
+                    fpss.push((frames * 1_000_000_000 / nanos, from..scene.objects.len()));
                     checkpoint += elapsed;
                     start = frame;
                     from = scene.objects.len();

--- a/rendy/examples/source_shaders/main.rs
+++ b/rendy/examples/source_shaders/main.rs
@@ -247,9 +247,7 @@ fn run(
         *control_flow = ControlFlow::Poll;
         match event {
             Event::WindowEvent { event, .. } => match event {
-                WindowEvent::CloseRequested => {
-                    *control_flow = ControlFlow::Exit
-                }
+                WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
                 _ => {}
             },
             Event::EventsCleared => {
@@ -303,9 +301,7 @@ fn main() {
 
     let mut graph_builder = GraphBuilder::<Backend, ()>::new();
 
-    let size = window
-        .inner_size()
-        .to_physical(window.hidpi_factor());
+    let size = window.inner_size().to_physical(window.hidpi_factor());
 
     let color = graph_builder.create_image(
         hal::image::Kind::D2(size.width as u32, size.height as u32, 1, 1),

--- a/rendy/examples/sprite/main.rs
+++ b/rendy/examples/sprite/main.rs
@@ -164,7 +164,7 @@ where
             .map_err(|e| {
                 log::error!("Unable to open {}: {:?}", "/examples/sprite/logo.png", e);
                 hal::pso::CreationError::Other
-            })?
+            })?,
         );
 
         let texture_builder = rendy::texture::image::load_from_image(
@@ -173,7 +173,8 @@ where
                 generate_mips: true,
                 ..Default::default()
             },
-        ).map_err(|e| {
+        )
+        .map_err(|e| {
             log::error!("Unable to load image: {:?}", e);
             hal::pso::CreationError::Other
         })?;
@@ -339,9 +340,7 @@ fn run(
         *control_flow = ControlFlow::Poll;
         match event {
             Event::WindowEvent { event, .. } => match event {
-                WindowEvent::CloseRequested => {
-                    *control_flow = ControlFlow::Exit
-                }
+                WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
                 _ => {}
             },
             Event::EventsCleared => {
@@ -395,9 +394,7 @@ fn main() {
 
     let mut graph_builder = GraphBuilder::<Backend, ()>::new();
 
-    let size = window
-        .inner_size()
-        .to_physical(window.hidpi_factor());
+    let size = window.inner_size().to_physical(window.hidpi_factor());
 
     let color = graph_builder.create_image(
         hal::image::Kind::D2(size.width as u32, size.height as u32, 1, 1),

--- a/rendy/examples/sprite/main.rs
+++ b/rendy/examples/sprite/main.rs
@@ -18,7 +18,7 @@ use rendy::{
     memory::Dynamic,
     mesh::PosTex,
     resource::{Buffer, BufferInfo, DescriptorSet, DescriptorSetLayout, Escape, Handle},
-    shader::{SourceShaderInfo, ShaderKind, SourceLanguage, SpirvShader},
+    shader::{ShaderKind, SourceLanguage, SourceShaderInfo, SpirvShader},
     texture::{image::ImageTextureConfig, Texture},
     wsi::winit::{
         event::{Event, WindowEvent},

--- a/rendy/examples/triangle/main.rs
+++ b/rendy/examples/triangle/main.rs
@@ -221,9 +221,7 @@ fn run(
         *control_flow = ControlFlow::Poll;
         match event {
             Event::WindowEvent { event, .. } => match event {
-                WindowEvent::CloseRequested => {
-                    *control_flow = ControlFlow::Exit
-                }
+                WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
                 _ => {}
             },
             Event::EventsCleared => {

--- a/resource/src/buffer.rs
+++ b/resource/src/buffer.rs
@@ -4,11 +4,11 @@ pub use gfx_hal::buffer::*;
 
 use {
     crate::{
-        CreationError,
         memory::{Block, Heaps, MappedRange, MemoryBlock, MemoryUsage},
         util::{device_owned, Device, DeviceId},
+        CreationError,
     },
-    gfx_hal::{Backend, device::Device as _},
+    gfx_hal::{device::Device as _, Backend},
     relevant::Relevant,
 };
 

--- a/resource/src/escape.rs
+++ b/resource/src/escape.rs
@@ -3,12 +3,12 @@
 //! for example many Vulkan resources must be destroyed by the same
 //! Vulkan instance that created them.  Because they need some outside
 //! context to be destroyed, Rust's `Drop` trait alone cannot handle them.
-//! The `Escape` wrapper helps the user handle these values by sending the 
-//! underlying value to a `Terminal` when it is dropped.  The user can 
-//! then remove those values from the `Terminal` elsewhere in the program 
+//! The `Escape` wrapper helps the user handle these values by sending the
+//! underlying value to a `Terminal` when it is dropped.  The user can
+//! then remove those values from the `Terminal` elsewhere in the program
 //! and destroy them however necessary.
-//! 
-//! Users are encouraged to dispose of values manually while using `Escape` 
+//!
+//! Users are encouraged to dispose of values manually while using `Escape`
 //! as just a safety net.
 
 use {

--- a/resource/src/image.rs
+++ b/resource/src/image.rs
@@ -4,12 +4,12 @@ pub use gfx_hal::image::*;
 
 use {
     crate::{
-        CreationError,
         escape::Handle,
         memory::{Block, Heaps, MemoryBlock, MemoryUsage},
         util::{device_owned, Device, DeviceId},
+        CreationError,
     },
-    gfx_hal::{format, Backend, device::Device as _},
+    gfx_hal::{device::Device as _, format, Backend},
     relevant::Relevant,
 };
 

--- a/resource/src/sampler/mod.rs
+++ b/resource/src/sampler/mod.rs
@@ -4,7 +4,7 @@ mod cache;
 
 use {
     crate::util::{device_owned, Device, DeviceId},
-    gfx_hal::{image::SamplerInfo, Backend, device::Device as _},
+    gfx_hal::{device::Device as _, image::SamplerInfo, Backend},
     relevant::Relevant,
 };
 

--- a/resource/src/set.rs
+++ b/resource/src/set.rs
@@ -4,7 +4,7 @@ use {
         escape::Handle,
         util::{device_owned, Device, DeviceId},
     },
-    gfx_hal::{pso::DescriptorSetLayoutBinding, Backend, device::Device as _},
+    gfx_hal::{device::Device as _, pso::DescriptorSetLayoutBinding, Backend},
     relevant::Relevant,
     smallvec::SmallVec,
 };

--- a/shader/Cargo.toml
+++ b/shader/Cargo.toml
@@ -13,7 +13,7 @@ description = "Rendy's shader compilation tool"
 [features]
 shader-compiler = ["shaderc"]
 spirv-reflection = [ "spirv-reflect" ]
-serde-1 = ["serde", "serde_bytes"]
+serde-1 = ["serde"]
 
 [dependencies]
 smallvec = "0.6"
@@ -25,5 +25,4 @@ rendy-factory = { version = "0.4.0", path = "../factory" }
 rendy-util = { version = "0.4.0", path = "../util" }
 shaderc = { version = "0.6", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
-serde_bytes = { version = "0.11", optional = true }
 spirv-reflect = { version = "0.2.1", optional = true }

--- a/shader/src/shaderc.rs
+++ b/shader/src/shaderc.rs
@@ -89,7 +89,6 @@ where
     }
 }
 
-
 /// Shader loaded from a source in the filesystem.
 #[derive(Clone, Copy, Debug)]
 pub struct SourceCodeShaderInfo<P, E, S> {
@@ -114,13 +113,13 @@ impl<P, E, S> SourceCodeShaderInfo<P, E, S> {
 }
 
 impl<P, E, S> SourceCodeShaderInfo<P, E, S>
-    where
-        E: AsRef<str>,
+where
+    E: AsRef<str>,
 {
     /// Precompile shader source code into Spir-V bytecode.
     pub fn precompile(&self) -> Result<SpirvShader, failure::Error>
-        where
-            Self: Shader,
+    where
+        Self: Shader,
     {
         Ok(SpirvShader::new(
             self.spirv()?.into_owned(),
@@ -131,10 +130,10 @@ impl<P, E, S> SourceCodeShaderInfo<P, E, S>
 }
 
 impl<P, E, S> Shader for SourceCodeShaderInfo<P, E, S>
-    where
-        P: AsRef<std::path::Path> + std::fmt::Debug,
-        E: AsRef<str>,
-        S: AsRef<str> + std::fmt::Debug,
+where
+    P: AsRef<std::path::Path> + std::fmt::Debug,
+    E: AsRef<str>,
+    S: AsRef<str> + std::fmt::Debug,
 {
     fn spirv(&self) -> Result<std::borrow::Cow<'static, [u32]>, failure::Error> {
         let artifact = shaderc::Compiler::new()
@@ -155,7 +154,7 @@ impl<P, E, S> Shader for SourceCodeShaderInfo<P, E, S>
                     ops.set_optimization_level(shaderc::OptimizationLevel::Performance);
                     ops
                 })
-                    .as_ref(),
+                .as_ref(),
             )?;
 
         Ok(std::borrow::Cow::Owned(artifact.as_binary().into()))
@@ -174,7 +173,10 @@ impl<P, E, S> Shader for SourceCodeShaderInfo<P, E, S>
 pub type SourceShaderInfo = SourceCodeShaderInfo<&'static str, &'static str, &'static str>;
 
 /// DEPRECATED. USE `PathBufShaderInfo` INSTEAD!
-#[deprecated(since = "0.2.1", note = "StaticShaderInfo will be removed in favor of PathBufShaderInfo soon. Please move to that implementation.")]
+#[deprecated(
+    since = "0.2.1",
+    note = "StaticShaderInfo will be removed in favor of PathBufShaderInfo soon. Please move to that implementation."
+)]
 pub type StaticShaderInfo = FileShaderInfo<&'static str, &'static str>;
 
 /// Shader info with a PathBuf for the path and static string for entry

--- a/texture/src/format/image.rs
+++ b/texture/src/format/image.rs
@@ -167,8 +167,7 @@ macro_rules! dyn_format {
 }
 
 /// pixel.channel_count() must be 4
-fn premultiply_alpha_4channel<P: image::Pixel<Subpixel = u8>>(pixel: &mut P) 
-{
+fn premultiply_alpha_4channel<P: image::Pixel<Subpixel = u8>>(pixel: &mut P) {
     let channels_mut = pixel.channels_mut();
     let alpha = channels_mut[3] as f32 / 255.0;
     channels_mut[0] = (channels_mut[0] as f32 * alpha).min(255.0).max(0.0) as u8;
@@ -177,8 +176,7 @@ fn premultiply_alpha_4channel<P: image::Pixel<Subpixel = u8>>(pixel: &mut P)
 }
 
 /// pixel.channel_count() must be 2
-fn premultiply_alpha_2channel<P: image::Pixel<Subpixel = u8>>(pixel: &mut P) 
-{
+fn premultiply_alpha_2channel<P: image::Pixel<Subpixel = u8>>(pixel: &mut P) {
     let channels_mut = pixel.channels_mut();
     let alpha = channels_mut[1] as f32 / 255.0;
     channels_mut[0] = (channels_mut[0] as f32 * alpha).min(255.0).max(0.0) as u8;
@@ -240,7 +238,7 @@ where
                         dyn_format!(Rg, _8, config.repr),
                         Swizzle(Component::R, Component::R, Component::R, Component::G),
                     )
-                },
+                }
                 DynamicImage::ImageRgb8(img) => (
                     img.into_vec(),
                     dyn_format!(Rgb, _8, config.repr),
@@ -257,7 +255,7 @@ where
                         dyn_format!(Rgba, _8, config.repr),
                         Swizzle::NO,
                     )
-                },
+                }
                 DynamicImage::ImageBgr8(img) => (
                     img.into_vec(),
                     dyn_format!(Bgr, _8, config.repr),
@@ -274,7 +272,7 @@ where
                         dyn_format!(Bgra, _8, config.repr),
                         Swizzle::NO,
                     )
-                },
+                }
             };
             (w, h, vec, format, swizzle)
         }

--- a/texture/src/texture.rs
+++ b/texture/src/texture.rs
@@ -5,8 +5,8 @@ use {
         memory::Data,
         pixel::AsPixel,
         resource::{
-            Escape, Handle, Image, ImageInfo, ImageView, ImageViewInfo, Sampler,
-            ImageCreationError, ImageViewCreationError,
+            Escape, Handle, Image, ImageCreationError, ImageInfo, ImageView,
+            ImageViewCreationError, ImageViewInfo, Sampler,
         },
         util::{cast_cow, cast_slice},
     },
@@ -358,26 +358,27 @@ impl<'a> TextureBuilder<'a> {
         unsafe {
             profile_scope!("upload_image");
 
-            factory.upload_image(
-                image.clone(),
-                self.data_width,
-                self.data_height,
-                image::SubresourceLayers {
-                    aspects: info.format.surface_desc().aspects,
-                    level: 0,
-                    layers: 0..info.kind.num_layers(),
-                },
-                image::Offset::ZERO,
-                info.kind.extent(),
-                buffer,
-                image::Layout::Undefined,
-                if !generate_mips || mip_levels == 1 {
-                    next_state
-                } else {
-                    mip_state
-                },
-            )
-            .map_err(BuildError::Upload)?;
+            factory
+                .upload_image(
+                    image.clone(),
+                    self.data_width,
+                    self.data_height,
+                    image::SubresourceLayers {
+                        aspects: info.format.surface_desc().aspects,
+                        level: 0,
+                        layers: 0..info.kind.num_layers(),
+                    },
+                    image::Offset::ZERO,
+                    info.kind.extent(),
+                    buffer,
+                    image::Layout::Undefined,
+                    if !generate_mips || mip_levels == 1 {
+                        next_state
+                    } else {
+                        mip_state
+                    },
+                )
+                .map_err(BuildError::Upload)?;
         }
 
         if mip_levels > 1 && generate_mips {
@@ -411,20 +412,21 @@ impl<'a> TextureBuilder<'a> {
 
         let view = {
             profile_scope!("create_image_view");
-            factory.create_image_view(
-                image.clone(),
-                ImageViewInfo {
-                    view_kind: self.view_kind,
-                    format: info.format,
-                    swizzle: double_swizzle(self.swizzle, transform_swizzle),
-                    range: image::SubresourceRange {
-                        aspects: info.format.surface_desc().aspects,
-                        levels: 0..info.levels,
-                        layers: 0..info.kind.num_layers(),
+            factory
+                .create_image_view(
+                    image.clone(),
+                    ImageViewInfo {
+                        view_kind: self.view_kind,
+                        format: info.format,
+                        swizzle: double_swizzle(self.swizzle, transform_swizzle),
+                        range: image::SubresourceRange {
+                            aspects: info.format.surface_desc().aspects,
+                            levels: 0..info.levels,
+                            layers: 0..info.kind.num_layers(),
+                        },
                     },
-                },
-            )
-            .map_err(BuildError::ImageView)?
+                )
+                .map_err(BuildError::ImageView)?
         };
 
         let sampler = factory

--- a/util/src/types/vertex.rs
+++ b/util/src/types/vertex.rs
@@ -3,8 +3,8 @@
 use derivative::Derivative;
 use gfx_hal::format::Format;
 use std::cmp::Ordering;
-use std::{borrow::Cow, fmt::Debug};
 use std::collections::HashMap;
+use std::{borrow::Cow, fmt::Debug};
 
 /// Trait for vertex attributes to implement
 pub trait AsAttribute: Debug + PartialEq + PartialOrd + Copy + Send + Sync + 'static {

--- a/wsi/src/lib.rs
+++ b/wsi/src/lib.rs
@@ -289,7 +289,9 @@ unsafe fn create_swapchain<B: Backend>(
 
     log::trace!("Surface formats: {:#?}. Pick {:#?}", formats, format);
 
-    if image_count < *capabilities.image_count.start() || image_count > *capabilities.image_count.end() {
+    if image_count < *capabilities.image_count.start()
+        || image_count > *capabilities.image_count.end()
+    {
         log::warn!(
             "Image count not supported. Supported: {:#?}, requested: {:#?}",
             capabilities.image_count,
@@ -306,7 +308,9 @@ unsafe fn create_swapchain<B: Backend>(
 
     assert!(
         capabilities.usage.contains(usage),
-        "Surface supports {:?}, but {:?} was requested", capabilities.usage, usage
+        "Surface supports {:?}, but {:?} was requested",
+        capabilities.usage,
+        usage
     );
 
     let extent = capabilities.current_extent.unwrap_or(suggest_extent);

--- a/wsi/src/lib.rs
+++ b/wsi/src/lib.rs
@@ -12,7 +12,7 @@
 )]
 
 use {
-    gfx_hal::{window::Extent2D, Backend, device::Device as _},
+    gfx_hal::{device::Device as _, window::Extent2D, Backend},
     rendy_resource::{Image, ImageInfo},
     rendy_util::{
         device_owned, instance_owned, rendy_with_dx12_backend, rendy_with_empty_backend,
@@ -88,7 +88,10 @@ pub enum SwapchainError {
 
 #[cfg(feature = "winit")]
 #[allow(unused)]
-fn create_surface<B: Backend>(instance: &Instance<B>, window: &winit::window::Window) -> B::Surface {
+fn create_surface<B: Backend>(
+    instance: &Instance<B>,
+    window: &winit::window::Window,
+) -> B::Surface {
     use rendy_util::identical_cast;
 
     // We perform identical type transmute.


### PR DESCRIPTION
This is a commit with changes I had to make while working on shadow mapping. The set includes:
- fix for broken serde feature after conversion to u32 spirv slices (`serde_bytes_u32`)
- removal of unnecessary assertion on spirv buffer length
- allow adding dynamic nodes to graph
- Allow creating `DescBuilder` with public `new`
- always pick first layer for bound attachments, comment explains why
- allow llvm inlining to better optimize texture conversion common cases

The rest is all pretty much just rustfmt. We probably need to add a CI step that verifies that, as we have quite a lot of noise due to not formatting the code immediately.