### PR TITLE
Clone transient resources iterator in render pass

### DIFF
--- a/graph/src/node/render/pass.rs
+++ b/graph/src/node/render/pass.rs
@@ -724,14 +724,14 @@ where
                         assert_eq!(group.colors(), subpass_colors);
                         assert_eq!(group.depth(), subpass_depth);
 
-                        let mut buffers = buffers.iter();
-                        let mut images = images.iter();
+                        let buffers = buffers.iter();
+                        let images = images.iter();
 
                         let buffers: Vec<_> = group
                             .buffers()
                             .into_iter()
                             .map(|(id, _)| {
-                                buffers
+                                buffers.clone()
                                     .find(|b| b.id == id)
                                     .expect("Transient buffer wasn't provided")
                                     .clone()
@@ -741,7 +741,7 @@ where
                             .images()
                             .into_iter()
                             .map(|(id, _)| {
-                                images
+                                images.clone()
                                     .find(|i| i.id == id)
                                     .expect("Transient image wasn't provided")
                                     .clone()

--- a/graph/src/node/render/pass.rs
+++ b/graph/src/node/render/pass.rs
@@ -724,14 +724,11 @@ where
                         assert_eq!(group.colors(), subpass_colors);
                         assert_eq!(group.depth(), subpass_depth);
 
-                        let buffers = buffers.iter();
-                        let images = images.iter();
-
                         let buffers: Vec<_> = group
                             .buffers()
                             .into_iter()
                             .map(|(id, _)| {
-                                buffers.clone()
+                                buffers.iter()
                                     .find(|b| b.id == id)
                                     .expect("Transient buffer wasn't provided")
                                     .clone()
@@ -741,7 +738,7 @@ where
                             .images()
                             .into_iter()
                             .map(|(id, _)| {
-                                images.clone()
+                                images.iter()
                                     .find(|i| i.id == id)
                                     .expect("Transient image wasn't provided")
                                     .clone()

--- a/shader/src/lib.rs
+++ b/shader/src/lib.rs
@@ -70,7 +70,6 @@ impl SpirvShader {
     /// Create Spir-V shader from bytes.
     pub fn new(spirv: Vec<u32>, stage: ShaderStageFlags, entrypoint: &str) -> Self {
         assert!(!spirv.is_empty());
-        assert_eq!(spirv.len() % 4, 0);
         Self {
             spirv,
             stage,


### PR DESCRIPTION
Not cloned iterator was used multiple times causing possible errors
during images lookup.

The same applies to buffers.

Fixes #190 