### PR TITLE
Fix serde support

### DIFF
--- a/shader/Cargo.toml
+++ b/shader/Cargo.toml
@@ -13,7 +13,7 @@ description = "Rendy's shader compilation tool"
 [features]
 shader-compiler = ["shaderc"]
 spirv-reflection = [ "spirv-reflect" ]
-serde-1 = ["serde", "serde_bytes"]
+serde-1 = ["serde", "gfx-hal/serde"]
 
 [dependencies]
 smallvec = "0.6"
@@ -25,5 +25,4 @@ rendy-factory = { version = "0.4.0", path = "../factory" }
 rendy-util = { version = "0.4.0", path = "../util" }
 shaderc = { version = "0.6", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
-serde_bytes = { version = "0.11", optional = true }
 spirv-reflect = { version = "0.2.1", optional = true }


### PR DESCRIPTION
Uses a hand-written serde implementation for `Vec<u32>`. Serializer is basically a copy of serde-bytes (plus the unsafe conversion), deserializer uses the endian-aware implementation from gfx-hal update.