### PR TITLE
Fixes #58 + minor fixes

### DIFF
--- a/mesh/src/mesh.rs
+++ b/mesh/src/mesh.rs
@@ -305,7 +305,7 @@ impl<'a> MeshBuilder<'a> {
                     factory.upload_buffer(
                         &mut buffer,
                         0,
-                        &indices,
+                        &**indices,
                         None,
                         BufferState::new(queue)
                             .with_access(gfx_hal::buffer::Access::INDEX_BUFFER_READ)

--- a/rendy/examples/quads/main.rs
+++ b/rendy/examples/quads/main.rs
@@ -433,7 +433,7 @@ where
                 .upload_buffer(
                     posvelbuff,
                     0,
-                    &POSVEL_DATA,
+                    &POSVEL_DATA[..],
                     None,
                     BufferState {
                         queue: QueueId {
@@ -582,7 +582,7 @@ fn run(
                 WindowEvent::Resized(_dims) => {
                     let started = std::time::Instant::now();
                     graph.take().unwrap().dispose(&mut factory, &());
-                    println!("Graph disposed in: {:?}", started.elapsed());
+                    log::trace!("Graph disposed in: {:?}", started.elapsed());
                     graph = Some(build_graph(&mut factory, &mut families, &window));
                 }
                 _ => {}
@@ -691,7 +691,7 @@ fn build_graph(
 
     let started = std::time::Instant::now();
     let graph = graph_builder.build(factory, families, &()).unwrap();
-    println!("Graph built in: {:?}", started.elapsed());
+    log::trace!("Graph built in: {:?}", started.elapsed());
     graph
 }
 

--- a/rendy/examples/source_shaders/main.rs
+++ b/rendy/examples/source_shaders/main.rs
@@ -283,7 +283,7 @@ fn run(
 #[cfg(any(feature = "dx12", feature = "metal", feature = "vulkan"))]
 fn main() {
     env_logger::Builder::from_default_env()
-        .filter_module("triangle", log::LevelFilter::Trace)
+        .filter_module("source_shaders", log::LevelFilter::Trace)
         .init();
 
     let config: Config = Default::default();


### PR DESCRIPTION
Fixes #58 + minor changes:
* The `source_shaders` example had incorrect logging filter
* The `quads` example used `println!` instead of logging-macros
