### PR TITLE
Use expect instead of unwrap for vertex shader

### DIFF
--- a/shader/src/lib.rs
+++ b/shader/src/lib.rs
@@ -121,7 +121,7 @@ impl<B: Backend> ShaderSet<B> {
             vertex: self
                 .shaders
                 .get(&ShaderStageFlags::VERTEX)
-                .unwrap()
+                .expect("ShaderSet doesn't contain vertex shader")
                 .get_entry_point()?
                 .unwrap(),
             fragment: match self.shaders.get(&ShaderStageFlags::FRAGMENT) {


### PR DESCRIPTION
While creating a minimal rendy example, I first started off with a pipeline with no shaders attached. I got a `thread 'main' panicked at 'called `Option::unwrap()` on a `None` value'` error from `shader/src/lib.rs:121`

Though probably an uncommon usage of rendy, it's a bit nicer to provide reasoning for why the program panicked.