### PR TITLE
Remove derivative from rendy

### DIFF
--- a/command/Cargo.toml
+++ b/command/Cargo.toml
@@ -16,8 +16,6 @@ profiler = ["thread_profiler/thread_profiler"]
 
 [dependencies]
 gfx-hal = { git = "https://github.com/gfx-rs/gfx", rev = "3d5db15661127c8cad8d85522a68ec36c82f6e69" }
-derivative = "1.0"
-failure = "0.1"
 relevant = { version = "0.4.0", features = ["log", "backtrace"] }
 smallvec = "0.6"
 rendy-util = { version = "0.4", path = "../util" }

--- a/command/src/buffer/encoder.rs
+++ b/command/src/buffer/encoder.rs
@@ -68,13 +68,23 @@ pub struct DispatchCommand {
 }
 
 /// Encoder for recording commands inside or outside renderpass.
-#[derive(derivative::Derivative)]
-#[derivative(Debug)]
 pub struct EncoderCommon<'a, B: gfx_hal::Backend, C> {
-    #[derivative(Debug = "ignore")]
     raw: &'a mut B::CommandBuffer,
     capability: C,
     family: FamilyId,
+}
+
+impl<'a, B, C> std::fmt::Debug for EncoderCommon<'a, B, C>
+where
+    B: gfx_hal::Backend,
+    C: std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EncoderCommon")
+            .field("capability", &self.capability)
+            .field("family", &self.family)
+            .finish()
+    }
 }
 
 impl<'a, B, C> EncoderCommon<'a, B, C>

--- a/command/src/buffer/mod.rs
+++ b/command/src/buffer/mod.rs
@@ -20,10 +20,7 @@ pub use self::{encoder::*, level::*, reset::*, state::*, submit::*, usage::*};
 /// Command buffer wrapper.
 /// This wrapper defines state with usage, level and ability to be individually reset at type level.
 /// This way many methods become safe.
-#[derive(derivative::Derivative)]
-#[derivative(Debug)]
 pub struct CommandBuffer<B: Backend, C, S, L = PrimaryLevel, R = NoIndividualReset> {
-    #[derivative(Debug = "ignore")]
     raw: std::ptr::NonNull<B::CommandBuffer>,
     capability: C,
     state: S,
@@ -31,6 +28,26 @@ pub struct CommandBuffer<B: Backend, C, S, L = PrimaryLevel, R = NoIndividualRes
     reset: R,
     family: FamilyId,
     relevant: relevant::Relevant,
+}
+
+impl<B, C, S, L, R> std::fmt::Debug for CommandBuffer<B, C, S, L, R>
+where
+    B: Backend,
+    C: std::fmt::Debug,
+    S: std::fmt::Debug,
+    L: std::fmt::Debug,
+    R: std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CommandPool")
+            .field("capability", &self.capability)
+            .field("state", &self.state)
+            .field("level", &self.level)
+            .field("reset", &self.reset)
+            .field("family", &self.family)
+            .field("relevant", &self.relevant)
+            .finish()
+    }
 }
 
 family_owned!(CommandBuffer<B, C, S, L, R>);

--- a/command/src/buffer/submit.rs
+++ b/command/src/buffer/submit.rs
@@ -9,20 +9,34 @@ use {
 };
 
 /// Structure contains command buffer ready for submission.
-#[derive(derivative::Derivative)]
-#[derivative(Debug)]
 pub struct Submit<
     B: gfx_hal::Backend,
     S = NoSimultaneousUse,
     L = PrimaryLevel,
     P = OutsideRenderPass,
 > {
-    #[derivative(Debug = "ignore")]
     raw: std::ptr::NonNull<B::CommandBuffer>,
     family: FamilyId,
     simultaneous: S,
     level: L,
     pass_continue: P,
+}
+
+impl<B, S, L, P> std::fmt::Debug for Submit<B, S, L, P>
+where
+    B: gfx_hal::Backend,
+    S: std::fmt::Debug,
+    L: std::fmt::Debug,
+    P: std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Submit")
+            .field("family", &self.family)
+            .field("simultaneous", &self.simultaneous)
+            .field("level", &self.level)
+            .field("pass_continue", &self.pass_continue)
+            .finish()
+    }
 }
 
 unsafe impl<B, S, L, P> Send for Submit<B, S, L, P>

--- a/command/src/family/mod.rs
+++ b/command/src/family/mod.rs
@@ -44,8 +44,7 @@ pub struct QueueId {
 /// Family of the command queues.
 /// Queues from one family can share resources and execute command buffers associated with the family.
 /// All queues of the family have same capabilities.
-#[derive(derivative::Derivative)]
-#[derivative(Debug)]
+#[derive(Debug)]
 pub struct Family<B: Backend, C = QueueType> {
     id: FamilyId,
     queues: Vec<Queue<B>>,

--- a/command/src/family/queue.rs
+++ b/command/src/family/queue.rs
@@ -5,13 +5,22 @@ use {
 };
 
 /// Command queue wrapper.
-#[derive(derivative::Derivative)]
-#[derivative(Debug)]
 pub struct Queue<B: Backend> {
-    #[derivative(Debug = "ignore")]
     raw: B::CommandQueue,
     id: QueueId,
     next_epoch: u64,
+}
+
+impl<B> std::fmt::Debug for Queue<B>
+where
+    B: Backend,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Queue")
+            .field("id", &self.id)
+            .field("next_epoch", &self.next_epoch)
+            .finish()
+    }
 }
 
 family_owned!(@NOCAP Queue<B> @ |q: &Self| q.id.family);

--- a/command/src/pool.rs
+++ b/command/src/pool.rs
@@ -8,15 +8,28 @@ use {
 /// Simple pool wrapper.
 /// Doesn't provide any guarantees.
 /// Wraps raw buffers into `CommandCommand buffer`.
-#[derive(derivative::Derivative)]
-#[derivative(Debug)]
 pub struct CommandPool<B: Backend, C = QueueType, R = NoIndividualReset> {
-    #[derivative(Debug = "ignore")]
     raw: B::CommandPool,
     capability: C,
     reset: R,
     family: FamilyId,
     relevant: relevant::Relevant,
+}
+
+impl<B, C, R> std::fmt::Debug for CommandPool<B, C, R>
+where
+    B: Backend,
+    C: std::fmt::Debug,
+    R: std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CommandPool")
+            .field("capability", &self.capability)
+            .field("reset", &self.reset)
+            .field("family", &self.family)
+            .field("relevant", &self.relevant)
+            .finish()
+    }
 }
 
 family_owned!(CommandPool<B, C, R>);

--- a/descriptor/Cargo.toml
+++ b/descriptor/Cargo.toml
@@ -11,7 +11,6 @@ categories = ["rendering"]
 description = "Rendy's descriptor allocator"
 
 [dependencies]
-derivative = "1.0"
 gfx-hal = { git = "https://github.com/gfx-rs/gfx", rev = "3d5db15661127c8cad8d85522a68ec36c82f6e69" }
 failure = "0.1"
 log = "0.4"

--- a/descriptor/src/allocator.rs
+++ b/descriptor/src/allocator.rs
@@ -8,6 +8,7 @@ use {
     smallvec::{smallvec, SmallVec},
     std::{
         collections::{HashMap, VecDeque},
+        fmt,
         ops::Deref,
     },
 };
@@ -56,10 +57,7 @@ struct Allocation<B: Backend> {
     pools: Vec<u64>,
 }
 
-#[derive(derivative::Derivative)]
-#[derivative(Debug)]
 struct DescriptorPool<B: Backend> {
-    #[derivative(Debug = "ignore")]
     raw: B::DescriptorPool,
     size: u32,
 
@@ -68,6 +66,19 @@ struct DescriptorPool<B: Backend> {
 
     // Number of sets freed (they can't be reused until gfx-hal 0.2)
     freed: u32,
+}
+
+impl<B> fmt::Debug for DescriptorPool<B>
+where
+    B: Backend,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DescriptorPool")
+            .field("size", &self.size)
+            .field("free", &self.free)
+            .field("freed", &self.freed)
+            .finish()
+    }
 }
 
 unsafe fn allocate_from_pool<B: Backend>(

--- a/factory/Cargo.toml
+++ b/factory/Cargo.toml
@@ -32,7 +32,6 @@ rendy-wsi = { version = "0.4.0", path = "../wsi" }
 rendy-util = { version = "0.4.0", path = "../util" }
 
 gfx-hal = { git = "https://github.com/gfx-rs/gfx", rev = "3d5db15661127c8cad8d85522a68ec36c82f6e69" }
-derivative = "1.0"
 either = "1.0"
 log = "0.4"
 parking_lot = "0.9"

--- a/factory/src/config.rs
+++ b/factory/src/config.rs
@@ -21,8 +21,7 @@ use crate::{
 /// [`BasicHeapsConfigure`]: struct.BasicHeapsConfigure.html
 /// [`QueuesConfigure`]: trait.QueuesConfigure.html
 /// [`OneGraphicsQueue`]: struct.OneGraphicsQueue.html
-#[derive(Clone, derivative::Derivative)]
-#[derivative(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Config<D = BasicDevicesConfigure, H = BasicHeapsConfigure, Q = OneGraphicsQueue> {
     /// Config to choose adapter.

--- a/frame/Cargo.toml
+++ b/frame/Cargo.toml
@@ -21,7 +21,6 @@ rendy-memory = { version = "0.4.0", path = "../memory" }
 rendy-resource = { version = "0.4.0", path = "../resource" }
 rendy-util = { version = "0.4.0", path = "../util" }
 
-derivative = "1.0"
 either = "1.5"
 gfx-hal = { git = "https://github.com/gfx-rs/gfx", rev = "3d5db15661127c8cad8d85522a68ec36c82f6e69" }
 failure = "0.1"

--- a/frame/src/cirque/mod.rs
+++ b/frame/src/cirque/mod.rs
@@ -114,13 +114,23 @@ impl<'a, T, I, P> ReadyRef<'a, T, I, P> {
 /// Resource cirque.
 /// It simplifies using multiple resources
 /// when same resource cannot be used simulteneously.
-#[derive(Debug, derivative::Derivative)]
-#[derivative(Default(bound = ""))]
+#[derive(Debug)]
 pub struct Cirque<T, I = T, P = T> {
     pending: VecDeque<(P, usize, Frame)>,
     ready: VecDeque<(T, usize)>,
     marker: std::marker::PhantomData<fn() -> I>,
     counter: usize,
+}
+
+impl<T, I, P> Default for Cirque<T, I, P> {
+    fn default() -> Self {
+        Cirque {
+            pending: VecDeque::default(),
+            ready: VecDeque::default(),
+            marker: std::marker::PhantomData,
+            counter: usize::default(),
+        }
+    }
 }
 
 impl<T, I, P> Cirque<T, I, P> {
@@ -181,9 +191,17 @@ impl<T, I, P> Cirque<T, I, P> {
 /// Resource cirque that depends on another one.
 /// It relies on trusted ready index instead of frame indices.
 /// It guarantees to always return same resource for same index.
-#[derive(Debug, derivative::Derivative)]
-#[derivative(Default(bound = ""))]
+#[derive(Debug)]
 pub struct DependentCirque<T, I = T, P = T> {
     values: Vec<either::Either<T, P>>,
     marker: std::marker::PhantomData<fn() -> I>,
+}
+
+impl<T, I, P> Default for DependentCirque<T, I, P> {
+    fn default() -> Self {
+        DependentCirque {
+            values: Vec::default(),
+            marker: std::marker::PhantomData,
+        }
+    }
 }

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -34,7 +34,6 @@ gfx-hal = { git = "https://github.com/gfx-rs/gfx", rev = "3d5db15661127c8cad8d85
 
 either = "1.5"
 bitflags = "1.0"
-derivative = "1.0"
 log = "0.4"
 relevant = { version = "0.4", features = ["log", "backtrace"] }
 serde = { version = "1.0", optional = true, features = ["derive"] }

--- a/graph/src/graph/mod.rs
+++ b/graph/src/graph/mod.rs
@@ -282,13 +282,26 @@ where
 }
 
 /// Build graph from nodes and resource.
-#[derive(derivative::Derivative)]
-#[derivative(Debug(bound = ""))]
 pub struct GraphBuilder<B: Backend, T: ?Sized> {
     nodes: Vec<Box<dyn NodeBuilder<B, T>>>,
     buffers: Vec<BufferInfo>,
     images: Vec<(ImageInfo, Option<gfx_hal::command::ClearValue>)>,
     frames_in_flight: u32,
+}
+
+impl<B, T> std::fmt::Debug for GraphBuilder<B, T>
+where
+    B: Backend,
+    T: ?Sized,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GraphBuilder")
+            .field("nodes", &self.nodes)
+            .field("buffers", &self.buffers)
+            .field("images", &self.images)
+            .field("frames_in_flight", &self.frames_in_flight)
+            .finish()
+    }
 }
 
 impl<B, T> GraphBuilder<B, T>

--- a/graph/src/node/mod.rs
+++ b/graph/src/node/mod.rs
@@ -320,14 +320,29 @@ pub trait NodeBuilder<B: Backend, T: ?Sized>: std::fmt::Debug {
 }
 
 /// Builder for the node.
-#[derive(derivative::Derivative)]
-#[derivative(Debug(bound = "N: std::fmt::Debug"))]
 pub struct DescBuilder<B: Backend, T: ?Sized, N> {
     desc: N,
     buffers: Vec<BufferId>,
     images: Vec<ImageId>,
     dependencies: Vec<NodeId>,
     marker: std::marker::PhantomData<fn(B, &T)>,
+}
+
+impl<B, T, N> std::fmt::Debug for DescBuilder<B, T, N>
+where
+    B: Backend,
+    T: ?Sized,
+    N: std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DescBuilder")
+            .field("desc", &self.desc)
+            .field("buffers", &self.buffers)
+            .field("images", &self.images)
+            .field("dependencies", &self.dependencies)
+            .field("marker", &self.marker)
+            .finish()
+    }
 }
 
 impl<B, T, N> DescBuilder<B, T, N>

--- a/memory/Cargo.toml
+++ b/memory/Cargo.toml
@@ -15,7 +15,6 @@ serde-1 = ["serde"]
 
 [dependencies]
 gfx-hal = { git = "https://github.com/gfx-rs/gfx", rev = "3d5db15661127c8cad8d85522a68ec36c82f6e69" }
-derivative = "1.0"
 failure = "0.1"
 log = "0.4"
 hibitset = {version = "0.6", default-features = false}

--- a/memory/src/allocator/linear.rs
+++ b/memory/src/allocator/linear.rs
@@ -9,19 +9,31 @@ use {
         util::*,
     },
     gfx_hal::{device::Device as _, Backend},
+    std::fmt,
 };
 
 /// Memory block allocated from `LinearAllocator`
-#[derive(derivative::Derivative)]
-#[derivative(Debug)]
 pub struct LinearBlock<B: Backend> {
-    // #[derivative(Debug(format_with = "::memory::memory_ptr_fmt"))]
     memory: *const Memory<B>,
     linear_index: u64,
     ptr: NonNull<u8>,
     range: Range<u64>,
-    #[derivative(Debug = "ignore")]
     relevant: relevant::Relevant,
+}
+
+impl<B> fmt::Debug for LinearBlock<B>
+where
+    B: Backend,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LinearBlock")
+            .field("memory", &self.memory)
+            .field("linear_index", &self.linear_index)
+            .field("ptr", &self.ptr)
+            .field("range", &self.range)
+            .field("relevant", &self.relevant)
+            .finish()
+    }
 }
 
 unsafe impl<B> Send for LinearBlock<B> where B: Backend {}
@@ -120,14 +132,24 @@ pub struct LinearAllocator<B: Backend> {
     lines: VecDeque<Line<B>>,
 }
 
-#[derive(derivative::Derivative)]
-#[derivative(Debug)]
 struct Line<B: Backend> {
     used: u64,
     free: u64,
-    #[derivative(Debug = "ignore")]
     memory: Box<Memory<B>>,
     ptr: NonNull<u8>,
+}
+
+impl<B> fmt::Debug for Line<B>
+where
+    B: Backend,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Line")
+            .field("used", &self.used)
+            .field("free", &self.free)
+            .field("ptr", &self.ptr)
+            .finish()
+    }
 }
 
 unsafe impl<B> Send for Line<B> where B: Backend {}

--- a/resource/Cargo.toml
+++ b/resource/Cargo.toml
@@ -16,7 +16,6 @@ no-slow-safety-checks = ["rendy-util/no-slow-safety-checks"]
 [dependencies]
 gfx-hal = { git = "https://github.com/gfx-rs/gfx", rev = "3d5db15661127c8cad8d85522a68ec36c82f6e69" }
 crossbeam-channel = "0.3"
-derivative = "1.0"
 log = "0.4"
 relevant = { version = "0.4", features = ["log", "backtrace"] }
 rendy-descriptor = { version = "0.4.0", path = "../descriptor" }

--- a/resource/src/escape.rs
+++ b/resource/src/escape.rs
@@ -153,10 +153,17 @@ impl<T> Drop for Terminal<T> {
 /// Permit sharing unlike [`Escape`]
 ///
 /// [`Escape`]: ./struct.Escape.html
-#[derive(derivative::Derivative, Debug)]
-#[derivative(Clone(bound = ""))]
+#[derive(Debug)]
 pub struct Handle<T> {
     inner: Arc<Escape<T>>,
+}
+
+impl<T> Clone for Handle<T> {
+    fn clone(&self) -> Self {
+        Handle {
+            inner: self.inner.clone(),
+        }
+    }
 }
 
 impl<T> From<Escape<T>> for Handle<T> {

--- a/resource/src/resources.rs
+++ b/resource/src/resources.rs
@@ -23,11 +23,19 @@ impl Epochs {
 }
 
 /// Resource handler.
-#[derive(Debug, derivative::Derivative)]
-#[derivative(Default(bound = ""))]
+#[derive(Debug)]
 pub struct ResourceTracker<T> {
     terminal: Terminal<T>,
     dropped: VecDeque<(Epochs, T)>,
+}
+
+impl<T> Default for ResourceTracker<T> {
+    fn default() -> Self {
+        ResourceTracker {
+            terminal: Terminal::default(),
+            dropped: VecDeque::default(),
+        }
+    }
 }
 
 impl<T> ResourceTracker<T> {

--- a/resource/src/sampler/cache.rs
+++ b/resource/src/sampler/cache.rs
@@ -11,10 +11,20 @@ use {
 };
 
 /// Sampler cache holds handlers to created samplers.
-#[derive(Debug, derivative::Derivative)]
-#[derivative(Default(bound = ""))]
+#[derive(Debug)]
 pub struct SamplerCache<B: Backend> {
     samplers: HashMap<SamplerInfo, Handle<Sampler<B>>>,
+}
+
+impl<B> Default for SamplerCache<B>
+where
+    B: Backend,
+{
+    fn default() -> Self {
+        SamplerCache {
+            samplers: HashMap::default(),
+        }
+    }
 }
 
 impl<B> SamplerCache<B>

--- a/shader/Cargo.toml
+++ b/shader/Cargo.toml
@@ -17,7 +17,6 @@ serde-1 = ["serde"]
 
 [dependencies]
 smallvec = "0.6"
-derivative = "1.0"
 log = "0.4"
 failure = "0.1"
 gfx-hal = { git = "https://github.com/gfx-rs/gfx", rev = "3d5db15661127c8cad8d85522a68ec36c82f6e69" }

--- a/shader/src/lib.rs
+++ b/shader/src/lib.rs
@@ -116,10 +116,20 @@ impl Shader for SpirvShader {
 }
 
 /// A `ShaderSet` object represents a merged collection of `ShaderStorage` structures, which reflects merged information for all shaders in the set.
-#[derive(derivative::Derivative, Debug)]
-#[derivative(Default(bound = ""))]
+#[derive(Debug)]
 pub struct ShaderSet<B: Backend> {
     shaders: HashMap<ShaderStageFlags, ShaderStorage<B>>,
+}
+
+impl<B> Default for ShaderSet<B>
+where
+    B: Backend,
+{
+    fn default() -> Self {
+        ShaderSet {
+            shaders: HashMap::default(),
+        }
+    }
 }
 
 impl<B: Backend> ShaderSet<B> {

--- a/texture/Cargo.toml
+++ b/texture/Cargo.toml
@@ -23,7 +23,6 @@ rendy-util = { version = "0.4.0", path = "../util" }
 
 gfx-hal = { git = "https://github.com/gfx-rs/gfx", rev = "3d5db15661127c8cad8d85522a68ec36c82f6e69" }
 
-derivative = "1.0"
 failure = "0.1"
 serde = { version = "1.0", optional = true }
 image = { version = "0.22.0", optional = true }

--- a/texture/src/format/image.rs
+++ b/texture/src/format/image.rs
@@ -1,16 +1,14 @@
 //! Module that turns an image into a `Texture`
 
 use crate::{pixel, MipLevels, TextureBuilder};
-use derivative::Derivative;
 
 use std::num::NonZeroU8;
 
 // reexport for easy usage in ImageTextureConfig
 pub use image::ImageFormat;
 
-#[derive(Derivative, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derivative(Default)]
 pub enum Repr {
     Float,
     Unorm,
@@ -19,8 +17,13 @@ pub enum Repr {
     Iscaled,
     Uint,
     Int,
-    #[derivative(Default)]
     Srgb,
+}
+
+impl Default for Repr {
+    fn default() -> Self {
+        Repr::Srgb
+    }
 }
 
 /// A description how to interpret loaded texture.
@@ -32,24 +35,22 @@ pub enum Repr {
 ///
 /// 1D arrays are treated as a sequence of rows, each being an array entry.
 /// 1D images are treated as a single sequence of pixels.
-#[derive(Derivative, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derivative(Default)]
 pub enum TextureKind {
     D1,
     D1Array,
-    #[derivative(Default)]
     D2,
-    D2Array {
-        layers: u16,
-    },
-    D3 {
-        depth: u32,
-    },
+    D2Array { layers: u16 },
+    D3 { depth: u32 },
     Cube,
-    CubeArray {
-        layers: u16,
-    },
+    CubeArray { layers: u16 },
+}
+
+impl Default for TextureKind {
+    fn default() -> Self {
+        TextureKind::D2
+    }
 }
 
 impl TextureKind {
@@ -82,13 +83,12 @@ impl TextureKind {
     }
 }
 
-#[derive(Derivative, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(
     feature = "serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(default)
 )]
-#[derivative(Default)]
 pub struct ImageTextureConfig {
     /// Interpret the image as given format.
     /// When `None`, format is determined automatically based on magic bytes.
@@ -97,18 +97,29 @@ pub struct ImageTextureConfig {
     pub format: Option<ImageFormat>,
     pub repr: Repr,
     pub kind: TextureKind,
-    #[derivative(Default(
-        value = "gfx_hal::image::SamplerInfo::new(gfx_hal::image::Filter::Linear, gfx_hal::image::WrapMode::Clamp)"
-    ))]
     pub sampler_info: gfx_hal::image::SamplerInfo,
-    #[derivative(Default(value = "false"))]
     /// Automatically generate mipmaps for this image
     pub generate_mips: bool,
-    #[derivative(Default(value = "false"))]
     /// Premultiply the alpha channel of the image, if there is one. Note that this
     /// means an image stored with non-premultiplied alpha will become premultiplied,
     /// rather than indicating that the supplied image is premultiplied to begin with.
     pub premultiply_alpha: bool,
+}
+
+impl Default for ImageTextureConfig {
+    fn default() -> Self {
+        ImageTextureConfig {
+            format: Option::default(),
+            repr: Repr::default(),
+            kind: TextureKind::default(),
+            sampler_info: gfx_hal::image::SamplerInfo::new(
+                gfx_hal::image::Filter::Linear,
+                gfx_hal::image::WrapMode::Clamp,
+            ),
+            generate_mips: false,
+            premultiply_alpha: false,
+        }
+    }
 }
 
 #[cfg(feature = "serde")]

--- a/texture/src/pixel.rs
+++ b/texture/src/pixel.rs
@@ -210,13 +210,6 @@ impl_pixel_repr! {
 /// One pixel
 /// By default deriving X adds T: X bound for all type parameters for the type.
 /// We use `derivative` here to override that.
-#[derive(derivative::Derivative)]
-#[derivative(
-    Clone(bound = ""),
-    Copy(bound = ""),
-    Debug(bound = ""),
-    Default(bound = "")
-)]
 #[repr(transparent)]
 pub struct Pixel<C, S, T>
 where
@@ -224,6 +217,38 @@ where
 {
     /// Pixel representation.
     pub repr: <C as PixelRepr<S, T>>::Repr,
+}
+
+impl<C, S, T> Copy for Pixel<C, S, T> where C: PixelRepr<S, T> {}
+impl<C, S, T> Clone for Pixel<C, S, T>
+where
+    C: PixelRepr<S, T>,
+{
+    fn clone(&self) -> Self {
+        Pixel {
+            repr: self.repr.clone(),
+        }
+    }
+}
+
+impl<C, S, T> Default for Pixel<C, S, T>
+where
+    C: PixelRepr<S, T>,
+{
+    fn default() -> Self {
+        Pixel {
+            repr: <C as PixelRepr<S, T>>::Repr::default(),
+        }
+    }
+}
+
+impl<C, S, T> std::fmt::Debug for Pixel<C, S, T>
+where
+    C: PixelRepr<S, T>,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Pixel").field("repr", &self.repr).finish()
+    }
 }
 
 /// AsPixel trait for extracting the underlying data representation information from a Rust data type

--- a/texture/src/texture.rs
+++ b/texture/src/texture.rs
@@ -10,11 +10,11 @@ use {
         },
         util::{cast_cow, cast_slice},
     },
-    derivative::Derivative,
     gfx_hal::{
         format::{Component, Format, Swizzle},
         image, Backend,
     },
+    std::fmt,
     std::num::NonZeroU8,
     thread_profiler::profile_scope,
 };
@@ -90,15 +90,13 @@ pub enum BuildError {
 }
 
 /// Generics-free texture builder.
-#[derive(Clone, Derivative)]
-#[derivative(Debug)]
+#[derive(Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// Struct for staging data in preparation of building a `Texture`
 pub struct TextureBuilder<'a> {
     kind: image::Kind,
     view_kind: image::ViewKind,
     format: Format,
-    #[derivative(Debug = "ignore")]
     data: std::borrow::Cow<'a, [u8]>,
     data_width: u32,
     data_height: u32,
@@ -106,6 +104,22 @@ pub struct TextureBuilder<'a> {
     swizzle: Swizzle,
     mip_levels: MipLevels,
     premultiplied: bool,
+}
+
+impl<'a> fmt::Debug for TextureBuilder<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TextureBuilder")
+            .field("kind", &self.kind)
+            .field("view_kind", &self.view_kind)
+            .field("format", &self.format)
+            .field("data_width", &self.data_width)
+            .field("data_height", &self.data_height)
+            .field("sampler_info", &self.sampler_info)
+            .field("swizzle", &self.swizzle)
+            .field("mip_levels", &self.mip_levels)
+            .field("premultiplied", &self.premultiplied)
+            .finish()
+    }
 }
 
 impl<'a> TextureBuilder<'a> {

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -31,7 +31,6 @@ gfx-backend-empty = { git = "https://github.com/gfx-rs/gfx", rev = "3d5db1566112
 gfx-backend-dx12 = { git = "https://github.com/gfx-rs/gfx", rev = "3d5db15661127c8cad8d85522a68ec36c82f6e69", features = ["winit"], optional = true }
 gfx-backend-metal = { git = "https://github.com/gfx-rs/gfx", rev = "3d5db15661127c8cad8d85522a68ec36c82f6e69", features = ["winit"], optional = true }
 gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "3d5db15661127c8cad8d85522a68ec36c82f6e69", features = ["winit"], optional = true }
-derivative = "1.0"
 lazy_static = "1.0"
 log = "0.4"
 parking_lot = "0.9"

--- a/util/src/types/vertex.rs
+++ b/util/src/types/vertex.rs
@@ -1,6 +1,5 @@
 //! Built-in vertex formats.
 
-use derivative::Derivative;
 use gfx_hal::format::Format;
 use std::cmp::Ordering;
 use std::collections::HashMap;
@@ -290,21 +289,30 @@ impl<N: Into<Cow<'static, str>>> AsAttributes for (Format, N) {
 type AttributeElem = gfx_hal::pso::Element<Format>;
 
 /// Vertex attribute type.
-#[derive(Clone, Debug, Derivative)]
-#[derivative(PartialEq, Eq, Hash)]
+#[derive(Clone, Debug)]
 pub struct Attribute {
     /// globally unique identifier for attribute's semantic
     uuid: AttrUuid,
     /// hal type with offset and format
     element: AttributeElem,
     /// Attribute array index. Matrix attributes are treated like array of vectors.
-    #[derivative(PartialEq = "ignore")]
-    #[derivative(Hash = "ignore")]
     index: u8,
     /// Attribute name as used in the shader
-    #[derivative(PartialEq = "ignore")]
-    #[derivative(Hash = "ignore")]
     name: Cow<'static, str>,
+}
+
+impl Eq for Attribute {}
+impl PartialEq for Attribute {
+    fn eq(&self, other: &Self) -> bool {
+        self.uuid.eq(&other.uuid) && self.element.eq(&other.element)
+    }
+}
+
+impl std::hash::Hash for Attribute {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.uuid.hash(state);
+        self.element.hash(state);
+    }
 }
 
 impl Attribute {

--- a/wsi/Cargo.toml
+++ b/wsi/Cargo.toml
@@ -23,7 +23,6 @@ rendy-resource = { version = "0.4.0", path = "../resource" }
 rendy-util = { version = "0.4.0", path = "../util" }
 
 gfx-hal = { git = "https://github.com/gfx-rs/gfx", rev = "3d5db15661127c8cad8d85522a68ec36c82f6e69" }
-derivative = "1.0"
 log = "0.4"
 relevant = { version = "0.4", features = ["log", "backtrace"] }
 smallvec = "0.6"


### PR DESCRIPTION
Removes the derivative dependency from crates that are using it, as mentioned in #203, replacing it with manual implementations of the corresponding traits.
