### PR TITLE
remove failure

### DIFF
--- a/command/Cargo.toml
+++ b/command/Cargo.toml
@@ -17,7 +17,6 @@ profiler = ["thread_profiler/thread_profiler"]
 [dependencies]
 gfx-hal = { git = "https://github.com/gfx-rs/gfx", rev = "3d5db15661127c8cad8d85522a68ec36c82f6e69" }
 derivative = "1.0"
-failure = "0.1"
 relevant = { version = "0.4.0", features = ["log", "backtrace"] }
 smallvec = "0.6"
 rendy-util = { version = "0.4", path = "../util" }

--- a/descriptor/Cargo.toml
+++ b/descriptor/Cargo.toml
@@ -13,7 +13,6 @@ description = "Rendy's descriptor allocator"
 [dependencies]
 derivative = "1.0"
 gfx-hal = { git = "https://github.com/gfx-rs/gfx", rev = "3d5db15661127c8cad8d85522a68ec36c82f6e69" }
-failure = "0.1"
 log = "0.4"
 relevant = { version = "0.4", features = ["log", "backtrace"] }
 smallvec = "0.6"

--- a/frame/Cargo.toml
+++ b/frame/Cargo.toml
@@ -24,7 +24,6 @@ rendy-util = { version = "0.4.0", path = "../util" }
 derivative = "1.0"
 either = "1.5"
 gfx-hal = { git = "https://github.com/gfx-rs/gfx", rev = "3d5db15661127c8cad8d85522a68ec36c82f6e69" }
-failure = "0.1"
 log = "0.4"
 relevant = { version = "0.4", features = ["log", "backtrace"] }
 smallvec = "0.6"

--- a/memory/Cargo.toml
+++ b/memory/Cargo.toml
@@ -16,7 +16,6 @@ serde-1 = ["serde"]
 [dependencies]
 gfx-hal = { git = "https://github.com/gfx-rs/gfx", rev = "3d5db15661127c8cad8d85522a68ec36c82f6e69" }
 derivative = "1.0"
-failure = "0.1"
 log = "0.4"
 hibitset = {version = "0.6", default-features = false}
 relevant = { version = "0.4", features = ["log", "backtrace"] }

--- a/memory/src/heaps/mod.rs
+++ b/memory/src/heaps/mod.rs
@@ -9,19 +9,27 @@ use {
 
 /// Possible errors returned by `Heaps`.
 #[allow(missing_copy_implementations)]
-#[derive(Debug, failure::Fail)]
+#[derive(Debug)]
 pub enum HeapsError {
     /// Memory allocation failure.
-    #[fail(display = "{:?}", _0)]
     AllocationError(gfx_hal::device::AllocationError),
-
     /// No memory types among required for resource with requested properties was found.
-    #[fail(
-        display = "Memory type among ({}) with properties ({:?}) not found",
-        _0, _1
-    )]
     NoSuitableMemory(u32, gfx_hal::memory::Properties),
 }
+
+impl std::fmt::Display for HeapsError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HeapsError::AllocationError(e) => write!(f, "{:?}", e),
+            HeapsError::NoSuitableMemory(e, e2) => write!(
+                f,
+                "Memory type among ({}) with properties ({:?}) not found",
+                e, e2
+            ),
+        }
+    }
+}
+impl std::error::Error for HeapsError {}
 
 impl From<gfx_hal::device::AllocationError> for HeapsError {
     fn from(error: gfx_hal::device::AllocationError) -> Self {

--- a/mesh/Cargo.toml
+++ b/mesh/Cargo.toml
@@ -25,7 +25,6 @@ rendy-util = { version = "0.4.0", path = "../util" }
 
 gfx-hal = { git = "https://github.com/gfx-rs/gfx", rev = "3d5db15661127c8cad8d85522a68ec36c82f6e69" }
 
-failure = "0.1"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 wavefront_obj = { version = "6.0", optional = true }
 smallvec = { version = "0.6" }

--- a/mesh/src/format/obj.rs
+++ b/mesh/src/format/obj.rs
@@ -7,23 +7,19 @@ use {
 };
 
 /// Load mesh data from obj.
-pub fn load_from_obj(
-    bytes: &[u8],
-) -> Result<Vec<(MeshBuilder<'static>, Option<String>)>, failure::Error> {
-    let string = std::str::from_utf8(bytes)?;
-    let set = obj::parse(string).map_err(|e| {
-        failure::format_err!(
+pub fn load_from_obj(bytes: &[u8]) -> Result<Vec<(MeshBuilder<'static>, Option<String>)>, String> {
+    let string = std::str::from_utf8(bytes).map_err(|e| e.to_string())?;
+    obj::parse(string).and_then(load_from_data).map_err(|e| {
+        format!(
             "Error during parsing obj-file at line '{}': {}",
-            e.line_number,
-            e.message
+            e.line_number, e.message
         )
-    })?;
-    load_from_data(set)
+    })
 }
 
 fn load_from_data(
     obj_set: obj::ObjSet,
-) -> Result<Vec<(MeshBuilder<'static>, Option<String>)>, failure::Error> {
+) -> Result<Vec<(MeshBuilder<'static>, Option<String>)>, wavefront_obj::ParseError> {
     // Takes a list of objects that contain geometries that contain shapes that contain
     // vertex/texture/normal indices into the main list of vertices, and converts to
     // MeshBuilders with Position, Normal, TexCoord.

--- a/mesh/src/mesh.rs
+++ b/mesh/src/mesh.rs
@@ -465,18 +465,25 @@ where
     }
 }
 
-/// failure::Error type returned by `Mesh::bind` in case of mesh's vertex buffers are incompatible with requested vertex formats.
-#[derive(failure::Fail, Clone, Debug)]
-#[fail(
-    display = "Vertex format {:?} is not compatible with any of {:?}.",
-    not_found, in_formats
-)]
+/// Error type returned by `Mesh::bind` in case of mesh's vertex buffers are incompatible with requested vertex formats.
+#[derive(Clone, Debug)]
 pub struct Incompatible {
     /// Format that was queried but was not found
     pub not_found: VertexFormat,
     /// List of formats that were available at query time
     pub in_formats: Vec<VertexFormat>,
 }
+
+impl std::fmt::Display for Incompatible {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Vertex format {:?} is not compatible with any of {:?}.",
+            self.not_found, self.in_formats
+        )
+    }
+}
+impl std::error::Error for Incompatible {}
 
 /// Helper function to find buffer with compatible format.
 fn find_compatible_buffer(

--- a/rendy/Cargo.toml
+++ b/rendy/Cargo.toml
@@ -67,7 +67,6 @@ rendy-texture = { version = "0.4.0", path = "../texture", optional = true }
 rendy-util = { version = "0.4.0", path = "../util" }
 rendy-wsi = { version = "0.4.0", path = "../wsi", optional = true }
 
-failure = "0.1"
 gfx-hal = { git = "https://github.com/gfx-rs/gfx", rev = "3d5db15661127c8cad8d85522a68ec36c82f6e69" }
 thread_profiler = "0.3"
 

--- a/shader/Cargo.toml
+++ b/shader/Cargo.toml
@@ -19,7 +19,6 @@ serde-1 = ["serde"]
 smallvec = "0.6"
 derivative = "1.0"
 log = "0.4"
-failure = "0.1"
 gfx-hal = { git = "https://github.com/gfx-rs/gfx", rev = "3d5db15661127c8cad8d85522a68ec36c82f6e69" }
 rendy-factory = { version = "0.4.0", path = "../factory" }
 rendy-util = { version = "0.4.0", path = "../util" }

--- a/shader/src/lib.rs
+++ b/shader/src/lib.rs
@@ -118,7 +118,7 @@ impl SpirvShader {
 impl Shader for SpirvShader {
     type Error = ShaderError;
 
-    fn spirv(&self) -> Result<std::borrow::Cow<'_, [u32]>, <Self as Shader>::Error> {
+    fn spirv(&self) -> Result<std::borrow::Cow<'_, [u32]>, ShaderError> {
         Ok(std::borrow::Cow::Borrowed(&self.spirv))
     }
 

--- a/shader/src/reflect/mod.rs
+++ b/shader/src/reflect/mod.rs
@@ -8,11 +8,16 @@ pub(crate) mod types;
 pub use types::ReflectTypeError;
 use types::*;
 
+/// The item kind that couldn't be retrieved from spirv-reflect.
 #[derive(Copy, Clone, Debug)]
 pub enum RetrievalKind {
+    /// Input attributes.
     InputAttrib,
+    /// Output attributes.
     OutputAttrib,
+    /// Descriptor sets.
     DescriptorSets,
+    /// Push constants.
     PushConstants,
 }
 
@@ -27,16 +32,25 @@ impl RetrievalKind {
     }
 }
 
-/// Error occurred during reflection.
+/// A reflection error.
 #[derive(Debug)]
 pub enum ReflectError {
+    /// An item could not be retrieved from spirv-reflect.
     Retrieval(RetrievalKind, String),
+    /// A spirv-reflect error occured.
     General(String),
+    /// An attribute by the given name does not exist.
     NameDoesNotExist(String),
+    /// The cache wasn't constructed for the shader.
     CacheNotConstructued(ShaderStageFlags),
+    /// The bindings between the shaders of a set did not match.
     BindingsMismatch(usize),
+    /// The SpirvCachedGfxDescription was not created.
     SpirvCachedGfxDescription,
+    /// An error occured while reflecting a type.
     Type(ReflectTypeError),
+    /// Neither a vertex nor a compute shader has been provided.
+    NoVertComputeProvided,
 }
 
 impl std::error::Error for ReflectError {}
@@ -64,6 +78,9 @@ impl std::fmt::Display for ReflectError {
                 "SpirvCachedGfxDescription not created for this reflection"
             ),
             ReflectError::Type(e) => write!(f, "{}", e),
+            ReflectError::NoVertComputeProvided => {
+                write!(f, "a vertex or compute shader must be provided")
+            }
         }
     }
 }

--- a/shader/src/reflect/mod.rs
+++ b/shader/src/reflect/mod.rs
@@ -5,7 +5,74 @@ use std::collections::HashMap;
 use std::ops::{Bound, Range, RangeBounds};
 
 pub(crate) mod types;
+pub use types::ReflectTypeError;
 use types::*;
+
+#[derive(Copy, Clone, Debug)]
+pub enum RetrievalKind {
+    InputAttrib,
+    OutputAttrib,
+    DescriptorSets,
+    PushConstants,
+}
+
+impl RetrievalKind {
+    fn as_str(&self) -> &'static str {
+        match *self {
+            RetrievalKind::InputAttrib => "input attributes",
+            RetrievalKind::OutputAttrib => "output attributes",
+            RetrievalKind::DescriptorSets => "descriptor sets",
+            RetrievalKind::PushConstants => "push constants",
+        }
+    }
+}
+
+/// Error occurred during reflection.
+#[derive(Debug)]
+pub enum ReflectError {
+    Retrieval(RetrievalKind, String),
+    General(String),
+    NameDoesNotExist(String),
+    CacheNotConstructued(ShaderStageFlags),
+    BindingsMismatch(usize),
+    SpirvCachedGfxDescription,
+    Type(ReflectTypeError),
+}
+
+impl std::error::Error for ReflectError {}
+impl std::fmt::Display for ReflectError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ReflectError::Retrieval(kind, msg) => write!(
+                f,
+                "failed to get {} from spirv-reflect: {}",
+                kind.as_str(),
+                msg
+            ),
+            ReflectError::General(msg) => write!(f, "{}", msg),
+            ReflectError::NameDoesNotExist(name) => {
+                write!(f, "attribute named {} does not exist", name)
+            }
+            ReflectError::CacheNotConstructued(flags) => {
+                write!(f, "cache isn't constructed for shader: {:?}", flags)
+            }
+            ReflectError::BindingsMismatch(set) => {
+                write!(f, "mismatching bindings between shaders for set {}", set)
+            }
+            ReflectError::SpirvCachedGfxDescription => write!(
+                f,
+                "SpirvCachedGfxDescription not created for this reflection"
+            ),
+            ReflectError::Type(e) => write!(f, "{}", e),
+        }
+    }
+}
+
+impl From<ReflectTypeError> for ReflectError {
+    fn from(e: ReflectTypeError) -> Self {
+        ReflectError::Type(e)
+    }
+}
 
 #[derive(Clone, Debug)]
 pub(crate) struct SpirvCachedGfxDescription {
@@ -33,6 +100,7 @@ pub struct SpirvReflection {
     /// Cached value of gfx-hal specific data
     pub(crate) cache: Option<SpirvCachedGfxDescription>,
 }
+
 impl Default for SpirvReflection {
     fn default() -> Self {
         Self {
@@ -57,7 +125,7 @@ impl SpirvReflection {
         output_attributes: HashMap<(String, u8), gfx_hal::pso::AttributeDesc>,
         descriptor_sets: Vec<Vec<gfx_hal::pso::DescriptorSetLayoutBinding>>,
         push_constants: Vec<(ShaderStageFlags, Range<u32>)>,
-    ) -> Result<Self, failure::Error> {
+    ) -> Result<Self, ReflectError> {
         Ok(SpirvReflection {
             output_attributes,
             input_attributes,
@@ -70,7 +138,7 @@ impl SpirvReflection {
         })
     }
 
-    pub(crate) fn compile_cache(mut self) -> Result<Self, failure::Error> {
+    pub(crate) fn compile_cache(mut self) -> Result<Self, ReflectError> {
         // BBreak apart the sets into the appropriate grouping
 
         let layout = if self.descriptor_sets.len() > 0 {
@@ -107,34 +175,25 @@ impl SpirvReflection {
     pub fn reflect(
         spirv: &[u32],
         entrypoint: Option<&str>,
-    ) -> Result<SpirvReflection, failure::Error> {
+    ) -> Result<SpirvReflection, ReflectError> {
         match ShaderModule::load_u32_data(spirv) {
             Ok(module) => {
                 let stage_flag = convert_stage(module.get_shader_stage());
 
                 let input_attributes =
                     generate_attributes(module.enumerate_input_variables(None).map_err(|e| {
-                        failure::format_err!(
-                            "Failed to get input attributes from spirv-reflect: {}",
-                            e
-                        )
+                        ReflectError::Retrieval(RetrievalKind::InputAttrib, e.to_string())
                     })?);
 
                 let output_attributes =
                     generate_attributes(module.enumerate_input_variables(None).map_err(|e| {
-                        failure::format_err!(
-                            "Failed to get output attributes from spirv-reflect: {}",
-                            e
-                        )
+                        ReflectError::Retrieval(RetrievalKind::OutputAttrib, e.to_string())
                     })?);
 
                 let descriptor_sets: Result<Vec<_>, _> = module
                     .enumerate_descriptor_sets(None)
                     .map_err(|e| {
-                        failure::format_err!(
-                            "Failed to get descriptor sets from spirv-reflect: {}",
-                            e
-                        )
+                        ReflectError::Retrieval(RetrievalKind::DescriptorSets, e.to_string())
                     })?
                     .iter()
                     .map(ReflectInto::<Vec<gfx_hal::pso::DescriptorSetLayoutBinding>>::reflect_into)
@@ -142,8 +201,7 @@ impl SpirvReflection {
 
                 // This is a fixup-step required because of our implementation. Because we dont pass the module around
                 // to the all the reflect_into API's, we need to fix up the shader stage here at the end. Kinda a hack
-                let mut descriptor_sets_final = descriptor_sets
-                    .map_err(|e| failure::format_err!("Failed to parse descriptor sets:: {}", e))?;
+                let mut descriptor_sets_final = descriptor_sets?;
                 descriptor_sets_final.iter_mut().for_each(|v| {
                     v.iter_mut()
                         .for_each(|mut set| set.stage_flags = stage_flag);
@@ -152,10 +210,7 @@ impl SpirvReflection {
                 let push_constants: Result<Vec<_>, _> = module
                     .enumerate_push_constant_blocks(None)
                     .map_err(|e| {
-                        failure::format_err!(
-                            "Failed to get push constants from spirv-reflect: {}",
-                            e
-                        )
+                        ReflectError::Retrieval(RetrievalKind::PushConstants, e.to_string())
                     })?
                     .iter()
                     .map(|c| convert_push_constant(stage_flag, c))
@@ -168,26 +223,26 @@ impl SpirvReflection {
                     Some(entrypoint.to_string()),
                     vec![(stage_flag, module.get_entry_point_name())],
                     input_attributes.map_err(|e| {
-                        failure::format_err!("Error parsing input attributes: {}", e)
+                        ReflectError::Retrieval(RetrievalKind::InputAttrib, e.to_string())
                     })?,
                     output_attributes.map_err(|e| {
-                        failure::format_err!("Error parsing output attributes: {}", e)
+                        ReflectError::Retrieval(RetrievalKind::OutputAttrib, e.to_string())
                     })?,
                     descriptor_sets_final,
                     push_constants?,
                 )
             }
-            Err(e) => failure::bail!("Failed to reflect data: {}", e),
+            Err(e) => return Err(ReflectError::General(e.to_string())),
         }
     }
 
     /// Returns attributes based on their names in rendy/gfx_hal format in the form of a `VertexFormat`. Note that attributes are sorted in their layout location
     /// order, not in the order provided.
-    pub fn attributes(&self, names: &[&str]) -> Result<VertexFormat, failure::Error> {
-        let cache = self.cache.as_ref().ok_or(failure::format_err!(
-            "Cache isn't constructed for shader: {:?}",
-            self.stage()
-        ))?;
+    pub fn attributes(&self, names: &[&str]) -> Result<VertexFormat, ReflectError> {
+        let cache = self
+            .cache
+            .as_ref()
+            .ok_or(ReflectError::CacheNotConstructued(self.stage()))?;
         let mut attributes = smallvec::SmallVec::<[_; 64]>::new();
 
         for name in names {
@@ -200,7 +255,7 @@ impl SpirvReflection {
             let before = attributes.len();
             attributes.extend(this_name_attributes);
             if attributes.len() == before {
-                failure::bail!("Attribute named {} does not exist", name);
+                return Err(ReflectError::NameDoesNotExist(name.to_string()));
             }
         }
         attributes.sort_by_key(|a| a.0);
@@ -217,11 +272,11 @@ impl SpirvReflection {
     pub fn attributes_range<R: RangeBounds<u32>>(
         &self,
         range: R,
-    ) -> Result<VertexFormat, failure::Error> {
-        let cache = self.cache.as_ref().ok_or(failure::format_err!(
-            "Cache isn't constructed for shader: {:?}",
-            self.stage()
-        ))?;
+    ) -> Result<VertexFormat, ReflectError> {
+        let cache = self
+            .cache
+            .as_ref()
+            .ok_or(ReflectError::CacheNotConstructued(self.stage()))?;
 
         let attributes = cache
             .vertices
@@ -235,13 +290,11 @@ impl SpirvReflection {
 
     /// Returns the merged descriptor set layouts of all shaders in this set in gfx_hal format in the form of a `Layout` structure.
     #[inline(always)]
-    pub fn layout(&self) -> Result<Layout, failure::Error> {
+    pub fn layout(&self) -> Result<Layout, ReflectError> {
         Ok(self
             .cache
             .as_ref()
-            .ok_or(failure::format_err!(
-                "SpirvCachedGfxDescription not created for this reflection"
-            ))?
+            .ok_or(ReflectError::SpirvCachedGfxDescription)?
             .layout
             .clone())
     }
@@ -257,7 +310,7 @@ impl SpirvReflection {
     pub fn push_constants(
         &self,
         range: Option<Range<usize>>,
-    ) -> Result<Vec<(ShaderStageFlags, Range<u32>)>, failure::Error> {
+    ) -> Result<Vec<(ShaderStageFlags, Range<u32>)>, ReflectError> {
         if range.is_some() {
             Ok(self
                 .push_constants
@@ -276,7 +329,7 @@ impl SpirvReflection {
     }
 }
 
-pub(crate) fn merge(reflections: &[SpirvReflection]) -> Result<SpirvReflection, failure::Error> {
+pub(crate) fn merge(reflections: &[SpirvReflection]) -> Result<SpirvReflection, ReflectError> {
     let mut descriptor_sets = Vec::<Vec<gfx_hal::pso::DescriptorSetLayoutBinding>>::new();
     let mut set_push_constants = Vec::new();
     let mut set_stage_flags = ShaderStageFlags::empty();
@@ -301,10 +354,7 @@ pub(crate) fn merge(reflections: &[SpirvReflection]) -> Result<SpirvReflection, 
             {
                 None => descriptor_sets.push(set.clone()),
                 Some(SetEquality::NotEqual) => {
-                    return Err(failure::format_err!(
-                        "Mismatching bindings between shaders for set #{}",
-                        n
-                    ));
+                    return Err(ReflectError::BindingsMismatch(n));
                 }
                 Some(SetEquality::SupersetOf) => {
                     descriptor_sets[n] = set.clone(); // Overwrite it

--- a/shader/src/reflect/types.rs
+++ b/shader/src/reflect/types.rs
@@ -5,16 +5,26 @@ use gfx_hal::format::Format;
 use spirv_reflect::types::*;
 use std::collections::HashMap;
 
+/// A type reflection error.
 #[derive(Copy, Clone, Debug)]
 pub enum ReflectTypeError {
+    /// Tried reflecting an undefined format.
     UndefinedFormat,
+    /// The conversion isn't supported.
     UnsupportedConversion,
+    /// An unrecognized numeric sign has been encountered.
     UnrecognizedNumericSignedness(u32),
+    /// Unrecognized numeric flags have been encountered.
     UnrecognizedNumericTypeFlags(ReflectTypeFlags),
+    /// An unrecognized numeric width has been encountered.
     UnrecognizedNumericTypeWidth(u32),
+    /// An unrecognized array count for the format has been encountered.
     UnrecognizedNumericArrayCount(Format, u32),
+    /// A vertex element could not be reflected.
     VertexElement,
+    /// A `AccelerationStructureNV` descriptor type has been encountered which cannot be handled.
     UnhandledAccelerationStructureNV,
+    /// An undefined descriptor type has been encountered which cannot be handled.
     UnhandledUndefined,
 }
 

--- a/shader/src/shaderc.rs
+++ b/shader/src/shaderc.rs
@@ -94,7 +94,7 @@ where
 {
     type Error = ShaderCError;
 
-    fn spirv(&self) -> Result<std::borrow::Cow<'static, [u32]>, <Self as Shader>::Error> {
+    fn spirv(&self) -> Result<std::borrow::Cow<'static, [u32]>, ShaderCError> {
         let code = std::fs::read_to_string(&self.path)?;
 
         let artifact = shaderc::Compiler::new()
@@ -178,7 +178,7 @@ where
 {
     type Error = ShaderCError;
 
-    fn spirv(&self) -> Result<std::borrow::Cow<'static, [u32]>, <Self as Shader>::Error> {
+    fn spirv(&self) -> Result<std::borrow::Cow<'static, [u32]>, ShaderCError> {
         let artifact = shaderc::Compiler::new()
             .ok_or(ShaderCError::Init)?
             .compile_into_spirv(

--- a/shader/src/shaderc.rs
+++ b/shader/src/shaderc.rs
@@ -1,5 +1,5 @@
 // This module is gated under "shader-compiler" feature
-use super::{Shader, ShaderError};
+use super::Shader;
 use crate::SpirvShader;
 pub use shaderc::{self, ShaderKind, SourceLanguage};
 
@@ -8,6 +8,45 @@ macro_rules! vk_make_version {
         let (major, minor, patch): (u32, u32, u32) = ($major, $minor, $patch);
         (major << 22) | (minor << 12) | patch
     }};
+}
+
+/// Error type returned by shader compiler functionality.
+#[derive(Debug)]
+pub enum ShaderCError {
+    /// Shaderc could not be initialized.
+    Init,
+    /// The given path is not a valid UTF-8 string.
+    NonUtf8Path(std::path::PathBuf),
+    /// An io error occured.
+    Io(std::io::Error),
+    /// Shaderc returned an error.
+    ShaderC(::shaderc::Error),
+}
+
+impl std::error::Error for ShaderCError {}
+impl std::fmt::Display for ShaderCError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ShaderCError::Init => write!(f, "failed to init Shaderc"),
+            ShaderCError::NonUtf8Path(path) => {
+                write!(f, "path {:?} is not valid UTF-8 string", path)
+            }
+            ShaderCError::Io(e) => write!(f, "{}", e),
+            ShaderCError::ShaderC(e) => write!(f, "{}", e),
+        }
+    }
+}
+
+impl From<std::io::Error> for ShaderCError {
+    fn from(e: std::io::Error) -> Self {
+        ShaderCError::Io(e)
+    }
+}
+
+impl From<::shaderc::Error> for ShaderCError {
+    fn from(e: ::shaderc::Error) -> Self {
+        ShaderCError::ShaderC(e)
+    }
 }
 
 /// Shader loaded from a source in the filesystem.
@@ -36,7 +75,7 @@ where
     E: AsRef<str>,
 {
     /// Precompile shader source code into Spir-V bytecode.
-    pub fn precompile(&self) -> Result<SpirvShader, ShaderError>
+    pub fn precompile(&self) -> Result<SpirvShader, <Self as Shader>::Error>
     where
         Self: Shader,
     {
@@ -53,21 +92,23 @@ where
     P: AsRef<std::path::Path> + std::fmt::Debug,
     E: AsRef<str>,
 {
-    fn spirv(&self) -> Result<std::borrow::Cow<'static, [u32]>, ShaderError> {
+    type Error = ShaderCError;
+
+    fn spirv(&self) -> Result<std::borrow::Cow<'static, [u32]>, <Self as Shader>::Error> {
         let code = std::fs::read_to_string(&self.path)?;
 
         let artifact = shaderc::Compiler::new()
-            .ok_or(ShaderError::Init)?
+            .ok_or(ShaderCError::Init)?
             .compile_into_spirv(
                 &code,
                 self.kind,
                 self.path
                     .as_ref()
                     .to_str()
-                    .ok_or_else(|| ShaderError::NonUtf8Path(self.path.as_ref().to_owned()))?,
+                    .ok_or_else(|| ShaderCError::NonUtf8Path(self.path.as_ref().to_owned()))?,
                 self.entry.as_ref(),
                 Some({
-                    let mut ops = shaderc::CompileOptions::new().ok_or(ShaderError::Init)?;
+                    let mut ops = shaderc::CompileOptions::new().ok_or(ShaderCError::Init)?;
                     ops.set_target_env(shaderc::TargetEnv::Vulkan, vk_make_version!(1, 0, 0));
                     ops.set_source_language(self.lang);
                     ops.set_generate_debug_info();
@@ -117,7 +158,7 @@ where
     E: AsRef<str>,
 {
     /// Precompile shader source code into Spir-V bytecode.
-    pub fn precompile(&self) -> Result<SpirvShader, ShaderError>
+    pub fn precompile(&self) -> Result<SpirvShader, <Self as Shader>::Error>
     where
         Self: Shader,
     {
@@ -135,19 +176,21 @@ where
     E: AsRef<str>,
     S: AsRef<str> + std::fmt::Debug,
 {
-    fn spirv(&self) -> Result<std::borrow::Cow<'static, [u32]>, ShaderError> {
+    type Error = ShaderCError;
+
+    fn spirv(&self) -> Result<std::borrow::Cow<'static, [u32]>, <Self as Shader>::Error> {
         let artifact = shaderc::Compiler::new()
-            .ok_or(ShaderError::Init)?
+            .ok_or(ShaderCError::Init)?
             .compile_into_spirv(
                 self.source.as_ref(),
                 self.kind,
                 self.path
                     .as_ref()
                     .to_str()
-                    .ok_or_else(|| ShaderError::NonUtf8Path(self.path.as_ref().to_owned()))?,
+                    .ok_or_else(|| ShaderCError::NonUtf8Path(self.path.as_ref().to_owned()))?,
                 self.entry.as_ref(),
                 Some({
-                    let mut ops = shaderc::CompileOptions::new().ok_or(ShaderError::Init)?;
+                    let mut ops = shaderc::CompileOptions::new().ok_or(ShaderCError::Init)?;
                     ops.set_target_env(shaderc::TargetEnv::Vulkan, vk_make_version!(1, 0, 0));
                     ops.set_source_language(self.lang);
                     ops.set_generate_debug_info();

--- a/texture/Cargo.toml
+++ b/texture/Cargo.toml
@@ -24,7 +24,6 @@ rendy-util = { version = "0.4.0", path = "../util" }
 gfx-hal = { git = "https://github.com/gfx-rs/gfx", rev = "3d5db15661127c8cad8d85522a68ec36c82f6e69" }
 
 derivative = "1.0"
-failure = "0.1"
 serde = { version = "1.0", optional = true }
 image = { version = "0.22.0", optional = true }
 palette = { version = "0.4", optional = true }

--- a/texture/src/format/image.rs
+++ b/texture/src/format/image.rs
@@ -186,7 +186,7 @@ fn premultiply_alpha_2channel<P: image::Pixel<Subpixel = u8>>(pixel: &mut P) {
 pub fn load_from_image<R>(
     mut reader: R,
     config: ImageTextureConfig,
-) -> Result<TextureBuilder<'static>, failure::Error>
+) -> Result<TextureBuilder<'static>, image::ImageError>
 where
     R: std::io::BufRead + std::io::Seek,
 {


### PR DESCRIPTION
This PR removes the last bits of the `failure` crate. There are a few things I wasn't sure about which I'm just gonna mention here(they all address `rendy-shader`). 

The `ShaderError` enum variants depend on features which can change the amount of variants of it, due to that I added an `__Unexhaustive` variant so toggling features on won't suddenly break matching code, whether this is the correct way to do this or not is something I don't know. Also regarding this enum's name, it clashes with the `ShaderError` of `gfx_hal`, which both are used in the `Shader` trait now, so maybe gfx_hals shader error should become a variant of this one so that the Shader trait returns the same error type for all of its functions preventing potential confusion.
The last point is that the errors for the shader crate are rather nested now which is probably not needed, but I wasn't certain what other way might be the preferred one here.

Note: it's also a shame that the `spirv-reflect` errors arent being returned as `'static` string slices, which they internally are, which forces the strings to be cloned so that they can be propagated. I already made a PR propagate the `'static` lifetime for them there(https://github.com/gwihlidal/spirv-reflect-rs/pull/9).