### PR TITLE
Revert PR #197 and re-implement to fix incorrect buffer writes

### DIFF
--- a/factory/src/factory.rs
+++ b/factory/src/factory.rs
@@ -398,24 +398,16 @@ where
         &self,
         buffer: &mut Buffer<B>,
         offset: u64,
-        content: &T,
-    ) -> Result<(), MapError>
-    where
-        T: ?Sized + 'static,
-    {
-        let content_size = std::mem::size_of_val(content);
-
+        content: &[T],
+    ) -> Result<(), MapError> {
         let content = std::slice::from_raw_parts(
-            {
-                let content_ptr: *const T = content;
-                content_ptr as *const u8
-            },
-            content_size,
+            content.as_ptr() as *const u8,
+            content.len() * std::mem::size_of::<T>(),
         );
 
-        let mut mapped = buffer.map(&self.device, offset..offset + content_size as u64)?;
+        let mut mapped = buffer.map(&self.device, offset..offset + content.len() as u64)?;
         mapped
-            .write(&self.device, 0..content_size as u64)?
+            .write(&self.device, 0..content.len() as u64)?
             .write(content);
         Ok(())
     }
@@ -445,17 +437,13 @@ where
         &self,
         buffer: &Buffer<B>,
         offset: u64,
-        content: &T,
+        content: &[T],
         last: Option<BufferState>,
         next: BufferState,
-    ) -> Result<(), UploadError>
-    where
-        T: ?Sized + 'static,
-    {
+    ) -> Result<(), UploadError> {
         assert!(buffer.info().usage.contains(buffer::Usage::TRANSFER_DST));
 
-        let content_size = std::mem::size_of_val(content) as u64;
-
+        let content_size = content.len() as u64 * std::mem::size_of::<T>() as u64;
         let mut staging = self
             .create_buffer(
                 BufferInfo {
@@ -556,20 +544,17 @@ where
         image_layers: SubresourceLayers,
         image_offset: image::Offset,
         image_extent: Extent,
-        content: &T,
+        content: &[T],
         last: impl Into<ImageStateOrLayout>,
         next: ImageState,
-    ) -> Result<(), UploadError>
-    where
-        T: ?Sized + 'static,
-    {
+    ) -> Result<(), UploadError> {
         assert!(image.info().usage.contains(image::Usage::TRANSFER_DST));
         assert_eq!(image.format().surface_desc().aspects, image_layers.aspects);
         assert!(image_layers.layers.start <= image_layers.layers.end);
         assert!(image_layers.layers.end <= image.kind().num_layers());
         assert!(image_layers.level <= image.info().levels);
 
-        let content_size = std::mem::size_of_val(content) as u64;
+        let content_size = content.len() as u64 * std::mem::size_of::<T>() as u64;
         let format_desc = image.format().surface_desc();
         let texels_count = (image_extent.width / format_desc.dim.0 as u32) as u64
             * (image_extent.height / format_desc.dim.1 as u32) as u64

--- a/factory/src/factory.rs
+++ b/factory/src/factory.rs
@@ -399,7 +399,10 @@ where
         buffer: &mut Buffer<B>,
         offset: u64,
         content: &[T],
-    ) -> Result<(), MapError> {
+    ) -> Result<(), MapError>
+    where
+        T: 'static + Copy,
+    {
         let content = std::slice::from_raw_parts(
             content.as_ptr() as *const u8,
             content.len() * std::mem::size_of::<T>(),
@@ -440,7 +443,10 @@ where
         content: &[T],
         last: Option<BufferState>,
         next: BufferState,
-    ) -> Result<(), UploadError> {
+    ) -> Result<(), UploadError>
+    where
+        T: 'static + Copy,
+    {
         assert!(buffer.info().usage.contains(buffer::Usage::TRANSFER_DST));
 
         let content_size = content.len() as u64 * std::mem::size_of::<T>() as u64;
@@ -547,7 +553,10 @@ where
         content: &[T],
         last: impl Into<ImageStateOrLayout>,
         next: ImageState,
-    ) -> Result<(), UploadError> {
+    ) -> Result<(), UploadError>
+    where
+        T: 'static + Copy,
+    {
         assert!(image.info().usage.contains(image::Usage::TRANSFER_DST));
         assert_eq!(image.format().surface_desc().aspects, image_layers.aspects);
         assert!(image_layers.layers.start <= image_layers.layers.end);

--- a/mesh/src/mesh.rs
+++ b/mesh/src/mesh.rs
@@ -305,7 +305,7 @@ impl<'a> MeshBuilder<'a> {
                     factory.upload_buffer(
                         &mut buffer,
                         0,
-                        &**indices,
+                        &indices,
                         None,
                         BufferState::new(queue)
                             .with_access(gfx_hal::buffer::Access::INDEX_BUFFER_READ)

--- a/rendy/examples/quads/main.rs
+++ b/rendy/examples/quads/main.rs
@@ -433,7 +433,7 @@ where
                 .upload_buffer(
                     posvelbuff,
                     0,
-                    &POSVEL_DATA[..],
+                    &POSVEL_DATA,
                     None,
                     BufferState {
                         queue: QueueId {
@@ -582,7 +582,7 @@ fn run(
                 WindowEvent::Resized(_dims) => {
                     let started = std::time::Instant::now();
                     graph.take().unwrap().dispose(&mut factory, &());
-                    log::trace!("Graph disposed in: {:?}", started.elapsed());
+                    println!("Graph disposed in: {:?}", started.elapsed());
                     graph = Some(build_graph(&mut factory, &mut families, &window));
                 }
                 _ => {}
@@ -691,7 +691,7 @@ fn build_graph(
 
     let started = std::time::Instant::now();
     let graph = graph_builder.build(factory, families, &()).unwrap();
-    log::trace!("Graph built in: {:?}", started.elapsed());
+    println!("Graph built in: {:?}", started.elapsed());
     graph
 }
 

--- a/rendy/examples/quads/main.rs
+++ b/rendy/examples/quads/main.rs
@@ -582,7 +582,7 @@ fn run(
                 WindowEvent::Resized(_dims) => {
                     let started = std::time::Instant::now();
                     graph.take().unwrap().dispose(&mut factory, &());
-                    println!("Graph disposed in: {:?}", started.elapsed());
+                    log::trace!("Graph disposed in: {:?}", started.elapsed());
                     graph = Some(build_graph(&mut factory, &mut families, &window));
                 }
                 _ => {}
@@ -691,7 +691,7 @@ fn build_graph(
 
     let started = std::time::Instant::now();
     let graph = graph_builder.build(factory, families, &()).unwrap();
-    println!("Graph built in: {:?}", started.elapsed());
+    log::trace!("Graph built in: {:?}", started.elapsed());
     graph
 }
 

--- a/rendy/examples/source_shaders/main.rs
+++ b/rendy/examples/source_shaders/main.rs
@@ -283,7 +283,7 @@ fn run(
 #[cfg(any(feature = "dx12", feature = "metal", feature = "vulkan"))]
 fn main() {
     env_logger::Builder::from_default_env()
-        .filter_module("source_shaders", log::LevelFilter::Trace)
+        .filter_module("triangle", log::LevelFilter::Trace)
         .init();
 
     let config: Config = Default::default();

--- a/rendy/examples/source_shaders/main.rs
+++ b/rendy/examples/source_shaders/main.rs
@@ -283,7 +283,7 @@ fn run(
 #[cfg(any(feature = "dx12", feature = "metal", feature = "vulkan"))]
 fn main() {
     env_logger::Builder::from_default_env()
-        .filter_module("triangle", log::LevelFilter::Trace)
+        .filter_module("source_shaders", log::LevelFilter::Trace)
         .init();
 
     let config: Config = Default::default();


### PR DESCRIPTION
#197  unintentionally allowed for incorrectly writing `Vec` types when collected and submitted. This was discussed in the PR and actually seen, where a crash was mentioned, but it was *incorrectly* assumed to be an upstream problem. The change in #197 caused `upload_*` functions to accept a plain `Vec` as `&T` can AsRef a `Vec`, which was then cast incorrectly to a u8 and submitted. 

This was only evident in the `quads` example because it is the only example which actually provides a `Vec` type (from a `Vec::collect` call) for a buffer upload.

This PR reverts #197  and changes the fix for #58 to the original concept of just bounding T: 'static + Copy, instead of changing from `&[T]` to `&T`. As discussed in #197, this will have problems with large arrays being submitted - but we can just ignore that, as its unrealistic; it is better to *correctly* accept `Vec` types for large arrays, instead of compensating for large static slices which will almost never exist.