### PR TITLE
Optimize build

### DIFF
--- a/command/Cargo.toml
+++ b/command/Cargo.toml
@@ -15,7 +15,6 @@ no-slow-safety-checks = ["rendy-core/no-slow-safety-checks"]
 profiler = ["thread_profiler/thread_profiler"]
 
 [dependencies]
-derivative = "1.0"
 relevant = { version = "0.4.0", features = ["log", "backtrace"] }
 smallvec = "0.6"
 rendy-core = { version = "0.5.0", path = "../core" }

--- a/command/src/buffer/encoder.rs
+++ b/command/src/buffer/encoder.rs
@@ -68,10 +68,8 @@ pub struct DispatchCommand {
 }
 
 /// Encoder for recording commands inside or outside renderpass.
-#[derive(derivative::Derivative)]
-#[derivative(Debug)]
+#[derive(Debug)]
 pub struct EncoderCommon<'a, B: rendy_core::hal::Backend, C> {
-    #[derivative(Debug = "ignore")]
     raw: &'a mut B::CommandBuffer,
     capability: C,
     family: FamilyId,

--- a/command/src/buffer/mod.rs
+++ b/command/src/buffer/mod.rs
@@ -20,10 +20,8 @@ pub use self::{encoder::*, level::*, reset::*, state::*, submit::*, usage::*};
 /// Command buffer wrapper.
 /// This wrapper defines state with usage, level and ability to be individually reset at type level.
 /// This way many methods become safe.
-#[derive(derivative::Derivative)]
-#[derivative(Debug)]
+#[derive(Debug)]
 pub struct CommandBuffer<B: Backend, C, S, L = PrimaryLevel, R = NoIndividualReset> {
-    #[derivative(Debug = "ignore")]
     raw: std::ptr::NonNull<B::CommandBuffer>,
     capability: C,
     state: S,

--- a/command/src/buffer/submit.rs
+++ b/command/src/buffer/submit.rs
@@ -9,15 +9,13 @@ use {
 };
 
 /// Structure contains command buffer ready for submission.
-#[derive(derivative::Derivative)]
-#[derivative(Debug)]
+#[derive(Debug)]
 pub struct Submit<
     B: rendy_core::hal::Backend,
     S = NoSimultaneousUse,
     L = PrimaryLevel,
     P = OutsideRenderPass,
 > {
-    #[derivative(Debug = "ignore")]
     raw: std::ptr::NonNull<B::CommandBuffer>,
     family: FamilyId,
     simultaneous: S,

--- a/command/src/family/mod.rs
+++ b/command/src/family/mod.rs
@@ -44,8 +44,7 @@ pub struct QueueId {
 /// Family of the command queues.
 /// Queues from one family can share resources and execute command buffers associated with the family.
 /// All queues of the family have same capabilities.
-#[derive(derivative::Derivative)]
-#[derivative(Debug)]
+#[derive(Debug)]
 pub struct Family<B: Backend, C = QueueType> {
     id: FamilyId,
     queues: Vec<Queue<B>>,

--- a/command/src/family/queue.rs
+++ b/command/src/family/queue.rs
@@ -5,10 +5,8 @@ use {
 };
 
 /// Command queue wrapper.
-#[derive(derivative::Derivative)]
-#[derivative(Debug)]
+#[derive(Debug)]
 pub struct Queue<B: Backend> {
-    #[derivative(Debug = "ignore")]
     raw: B::CommandQueue,
     id: QueueId,
     next_epoch: u64,

--- a/command/src/pool.rs
+++ b/command/src/pool.rs
@@ -8,10 +8,8 @@ use {
 /// Simple pool wrapper.
 /// Doesn't provide any guarantees.
 /// Wraps raw buffers into `CommandCommand buffer`.
-#[derive(derivative::Derivative)]
-#[derivative(Debug)]
+#[derive(Debug)]
 pub struct CommandPool<B: Backend, C = QueueType, R = NoIndividualReset> {
-    #[derivative(Debug = "ignore")]
     raw: B::CommandPool,
     capability: C,
     reset: R,

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -29,7 +29,6 @@ no-slow-safety-checks = []
 gfx-hal = { git = "https://github.com/gfx-rs/gfx", rev = "46386475f7e823e807ec984c372ffe04dcc0a22b" }
 gfx-backend-empty = { git = "https://github.com/gfx-rs/gfx", rev = "46386475f7e823e807ec984c372ffe04dcc0a22b", optional = true }
 gfx-backend-gl = { git = "https://github.com/gfx-rs/gfx", rev = "46386475f7e823e807ec984c372ffe04dcc0a22b", features = ["glutin"], optional = true }
-derivative = "1.0"
 lazy_static = "1.0"
 log = "0.4"
 parking_lot = "0.9"

--- a/core/src/backend.rs
+++ b/core/src/backend.rs
@@ -398,17 +398,17 @@ macro_rules! rendy_backend {
     }) => {{#[allow(unreachable_code, irrefutable_let_patterns)]
         || -> _ {
             #[allow(unused)] use $enum_type as EnumType;
-            $($crate::rendy_with_dx12_backend!(if let EnumType :: Dx12 = $target { return { $dx12_code }; }))?;
-            $($crate::rendy_with_empty_backend!(if let EnumType :: Empty = $target { return { $empty_code }; }))?;
-            $($crate::rendy_with_gl_backend!(if let EnumType :: Gl = $target { return { $gl_code }; }))?;
-            $($crate::rendy_with_metal_backend!(if let EnumType :: Metal = $target { return { $metal_code }; }))?;
-            $($crate::rendy_with_vulkan_backend!(if let EnumType :: Vulkan = $target { return { $vulkan_code }; }))?;
+            $($crate::rendy_with_dx12_backend!(if let EnumType :: Dx12 = $target { return { $dx12_code }; });)?
+            $($crate::rendy_with_empty_backend!(if let EnumType :: Empty = $target { return { $empty_code }; });)?
+            $($crate::rendy_with_gl_backend!(if let EnumType :: Gl = $target { return { $gl_code }; });)?
+            $($crate::rendy_with_metal_backend!(if let EnumType :: Metal = $target { return { $metal_code }; });)?
+            $($crate::rendy_with_vulkan_backend!(if let EnumType :: Vulkan = $target { return { $vulkan_code }; });)?
 
-            $($crate::rendy_with_dx12_backend!(if let EnumType :: Dx12 = $target { $(use $crate::dx12 as $back;)? return { $code }; }))?;
-            $($crate::rendy_with_empty_backend!(if let EnumType :: Empty = $target { $(use $crate::empty as $back;)? return { $code }; }))?;
-            $($crate::rendy_with_gl_backend!(if let EnumType :: Gl = $target { $(use $crate::gl as $back;)? return { $code }; }))?;
-            $($crate::rendy_with_metal_backend!(if let EnumType :: Metal = $target { $(use $crate::metal as $back;)? return { $code }; }))?;
-            $($crate::rendy_with_vulkan_backend!(if let EnumType :: Vulkan = $target { $(use $crate::vulkan as $back;)? return { $code }; }))?;
+            $($crate::rendy_with_dx12_backend!(if let EnumType :: Dx12 = $target { $(use $crate::dx12 as $back;)? return { $code }; });)?
+            $($crate::rendy_with_empty_backend!(if let EnumType :: Empty = $target { $(use $crate::empty as $back;)? return { $code }; });)?
+            $($crate::rendy_with_gl_backend!(if let EnumType :: Gl = $target { $(use $crate::gl as $back;)? return { $code }; });)?
+            $($crate::rendy_with_metal_backend!(if let EnumType :: Metal = $target { $(use $crate::metal as $back;)? return { $code }; });)?
+            $($crate::rendy_with_vulkan_backend!(if let EnumType :: Vulkan = $target { $(use $crate::vulkan as $back;)? return { $code }; });)?
 
             unreachable!()
         }()
@@ -424,17 +424,17 @@ macro_rules! rendy_backend {
     }) => {{#[allow(unreachable_code, irrefutable_let_patterns)]
         || -> _ {
             #[allow(unused)] use $enum_type as EnumType;
-            $($crate::rendy_with_dx12_backend!(if let EnumType :: Dx12($dx12_pat) = $target { return { $dx12_code }; }))?;
-            $($crate::rendy_with_empty_backend!(if let EnumType :: Empty($empty_pat) = $target { return { $empty_code }; }))?;
-            $($crate::rendy_with_gl_backend!(if let EnumType :: Gl($gl_pat) = $target { return { $gl_code }; }))?;
-            $($crate::rendy_with_metal_backend!(if let EnumType :: Metal($metal_pat) = $target { return { $metal_code }; }))?;
-            $($crate::rendy_with_vulkan_backend!(if let EnumType :: Vulkan($vulkan_pat) = $target { return { $vulkan_code }; }))?;
+            $($crate::rendy_with_dx12_backend!(if let EnumType :: Dx12($dx12_pat) = $target { return { $dx12_code }; });)?
+            $($crate::rendy_with_empty_backend!(if let EnumType :: Empty($empty_pat) = $target { return { $empty_code }; });)?
+            $($crate::rendy_with_gl_backend!(if let EnumType :: Gl($gl_pat) = $target { return { $gl_code }; });)?
+            $($crate::rendy_with_metal_backend!(if let EnumType :: Metal($metal_pat) = $target { return { $metal_code }; });)?
+            $($crate::rendy_with_vulkan_backend!(if let EnumType :: Vulkan($vulkan_pat) = $target { return { $vulkan_code }; });)?
 
-            $($crate::rendy_with_dx12_backend!(if let EnumType :: Dx12($pat) = $target { $(use $crate::dx12 as $back;)? return { $code }; }))?;
-            $($crate::rendy_with_empty_backend!(if let EnumType :: Empty($pat) = $target { $(use $crate::empty as $back;)? return { $code }; }))?;
-            $($crate::rendy_with_gl_backend!(if let EnumType :: Gl($pat) = $target { $(use $crate::gl as $back;)? return { $code }; }))?;
-            $($crate::rendy_with_metal_backend!(if let EnumType :: Metal($pat) = $target { $(use $crate::metal as $back;)? return { $code }; }))?;
-            $($crate::rendy_with_vulkan_backend!(if let EnumType :: Vulkan($pat) = $target { $(use $crate::vulkan as $back;)? return { $code }; }))?;
+            $($crate::rendy_with_dx12_backend!(if let EnumType :: Dx12($pat) = $target { $(use $crate::dx12 as $back;)? return { $code }; });)?
+            $($crate::rendy_with_empty_backend!(if let EnumType :: Empty($pat) = $target { $(use $crate::empty as $back;)? return { $code }; });)?
+            $($crate::rendy_with_gl_backend!(if let EnumType :: Gl($pat) = $target { $(use $crate::gl as $back;)? return { $code }; });)?
+            $($crate::rendy_with_metal_backend!(if let EnumType :: Metal($pat) = $target { $(use $crate::metal as $back;)? return { $code }; });)?
+            $($crate::rendy_with_vulkan_backend!(if let EnumType :: Vulkan($pat) = $target { $(use $crate::vulkan as $back;)? return { $code }; });)?
 
             unreachable!()
         }()
@@ -449,17 +449,17 @@ macro_rules! rendy_backend {
         $($(use $back:ident;)?_ => $code:block)?
     }) => {{#[allow(unreachable_code, irrefutable_let_patterns)]
         || -> _ {
-            $($crate::rendy_with_dx12_backend!(if let $crate::EnabledBackend::Dx12 = $crate::EnabledBackend::which::<$target>() { return { $dx12_code }; }))?;
-            $($crate::rendy_with_empty_backend!(if let $crate::EnabledBackend::Empty = $crate::EnabledBackend::which::<$target>() { return { $empty_code }; }))?;
-            $($crate::rendy_with_gl_backend!(if let $crate::EnabledBackend::Gl = $crate::EnabledBackend::which::<$target>() { return { $gl_code }; }))?;
-            $($crate::rendy_with_metal_backend!(if let $crate::EnabledBackend::Metal = $crate::EnabledBackend::which::<$target>() { return { $metal_code }; }))?;
-            $($crate::rendy_with_vulkan_backend!(if let $crate::EnabledBackend::Vulkan = $crate::EnabledBackend::which::<$target>() { return { $vulkan_code }; }))?;
+            $($crate::rendy_with_dx12_backend!(if let $crate::EnabledBackend::Dx12 = $crate::EnabledBackend::which::<$target>() { return { $dx12_code }; });)?
+            $($crate::rendy_with_empty_backend!(if let $crate::EnabledBackend::Empty = $crate::EnabledBackend::which::<$target>() { return { $empty_code }; });)?
+            $($crate::rendy_with_gl_backend!(if let $crate::EnabledBackend::Gl = $crate::EnabledBackend::which::<$target>() { return { $gl_code }; });)?
+            $($crate::rendy_with_metal_backend!(if let $crate::EnabledBackend::Metal = $crate::EnabledBackend::which::<$target>() { return { $metal_code }; });)?
+            $($crate::rendy_with_vulkan_backend!(if let $crate::EnabledBackend::Vulkan = $crate::EnabledBackend::which::<$target>() { return { $vulkan_code }; });)?
 
-            $($crate::rendy_with_dx12_backend!(if let $crate::EnabledBackend::Dx12 = $crate::EnabledBackend::which::<$target>() { $(use $crate::dx12 as $back;)? return { $code }; }))?;
-            $($crate::rendy_with_empty_backend!(if let $crate::EnabledBackend::Empty = $crate::EnabledBackend::which::<$target>() { $(use $crate::empty as $back;)? return { $code }; }))?;
-            $($crate::rendy_with_gl_backend!(if let $crate::EnabledBackend::Gl = $crate::EnabledBackend::which::<$target>() { $(use $crate::gl as $back;)? return { $code }; }))?;
-            $($crate::rendy_with_metal_backend!(if let $crate::EnabledBackend::Metal = $crate::EnabledBackend::which::<$target>() { $(use $crate::metal as $back;)? return { $code }; }))?;
-            $($crate::rendy_with_vulkan_backend!(if let $crate::EnabledBackend::Vulkan = $crate::EnabledBackend::which::<$target>() { $(use $crate::vulkan as $back;)? return { $code }; }))?;
+            $($crate::rendy_with_dx12_backend!(if let $crate::EnabledBackend::Dx12 = $crate::EnabledBackend::which::<$target>() { $(use $crate::dx12 as $back;)? return { $code }; });)?
+            $($crate::rendy_with_empty_backend!(if let $crate::EnabledBackend::Empty = $crate::EnabledBackend::which::<$target>() { $(use $crate::empty as $back;)? return { $code }; });)?
+            $($crate::rendy_with_gl_backend!(if let $crate::EnabledBackend::Gl = $crate::EnabledBackend::which::<$target>() { $(use $crate::gl as $back;)? return { $code }; });)?
+            $($crate::rendy_with_metal_backend!(if let $crate::EnabledBackend::Metal = $crate::EnabledBackend::which::<$target>() { $(use $crate::metal as $back;)? return { $code }; });)?
+            $($crate::rendy_with_vulkan_backend!(if let $crate::EnabledBackend::Vulkan = $crate::EnabledBackend::which::<$target>() { $(use $crate::vulkan as $back;)? return { $code }; });)?
 
             unreachable!()
         }()

--- a/core/src/types/vertex.rs
+++ b/core/src/types/vertex.rs
@@ -1,7 +1,6 @@
 //! Built-in vertex formats.
 
 use crate::hal::format::Format;
-use derivative::Derivative;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::{borrow::Cow, fmt::Debug};
@@ -290,21 +289,34 @@ impl<N: Into<Cow<'static, str>>> AsAttributes for (Format, N) {
 type AttributeElem = crate::hal::pso::Element<Format>;
 
 /// Vertex attribute type.
-#[derive(Clone, Debug, Derivative)]
-#[derivative(PartialEq, Eq, Hash)]
+#[derive(Clone, Debug)]
 pub struct Attribute {
     /// globally unique identifier for attribute's semantic
     uuid: AttrUuid,
     /// hal type with offset and format
     element: AttributeElem,
     /// Attribute array index. Matrix attributes are treated like array of vectors.
-    #[derivative(PartialEq = "ignore")]
-    #[derivative(Hash = "ignore")]
     index: u8,
     /// Attribute name as used in the shader
-    #[derivative(PartialEq = "ignore")]
-    #[derivative(Hash = "ignore")]
     name: Cow<'static, str>,
+}
+
+impl PartialEq for Attribute {
+    fn eq(&self, other: &Self) -> bool {
+        self.uuid == other.uuid && self.element == other.element
+    }
+}
+
+impl Eq for Attribute {}
+
+impl std::hash::Hash for Attribute {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: std::hash::Hasher,
+    {
+        self.uuid.hash(state);
+        self.element.hash(state);
+    }
 }
 
 impl Attribute {

--- a/descriptor/Cargo.toml
+++ b/descriptor/Cargo.toml
@@ -11,8 +11,7 @@ categories = ["rendering"]
 description = "Rendy's descriptor allocator"
 
 [dependencies]
-derivative = "1.0"
-rendy-core = { version = "0.5.0", path = "../core" }
+gfx-hal = { git = "https://github.com/gfx-rs/gfx", rev = "46386475f7e823e807ec984c372ffe04dcc0a22b" }
 log = "0.4"
 relevant = { version = "0.4", features = ["log", "backtrace"] }
 smallvec = "0.6"

--- a/descriptor/src/allocator.rs
+++ b/descriptor/src/allocator.rs
@@ -1,6 +1,6 @@
 use {
     crate::ranges::*,
-    rendy_core::hal::{
+    gfx_hal::{
         device::{Device, OutOfMemory},
         pso::{AllocationError, DescriptorPool as _, DescriptorPoolCreateFlags},
         Backend,
@@ -56,10 +56,8 @@ struct Allocation<B: Backend> {
     pools: Vec<u64>,
 }
 
-#[derive(derivative::Derivative)]
-#[derivative(Debug)]
+#[derive(Debug)]
 struct DescriptorPool<B: Backend> {
-    #[derivative(Debug = "ignore")]
     raw: B::DescriptorPool,
     size: u32,
 

--- a/descriptor/src/ranges.rs
+++ b/descriptor/src/ranges.rs
@@ -3,7 +3,7 @@ use std::{
     ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign},
 };
 
-pub use rendy_core::hal::pso::{DescriptorRangeDesc, DescriptorSetLayoutBinding, DescriptorType};
+pub use gfx_hal::pso::{DescriptorRangeDesc, DescriptorSetLayoutBinding, DescriptorType};
 
 const DESCRIPTOR_TYPES_COUNT: usize = 11;
 

--- a/factory/Cargo.toml
+++ b/factory/Cargo.toml
@@ -32,7 +32,6 @@ rendy-descriptor = { version = "0.5.0", path = "../descriptor" }
 rendy-wsi = { version = "0.5.0", path = "../wsi" }
 rendy-core = { version = "0.5.0", path = "../core" }
 
-derivative = "1.0"
 either = "1.0"
 log = "0.4"
 parking_lot = "0.9"

--- a/factory/src/config.rs
+++ b/factory/src/config.rs
@@ -21,8 +21,7 @@ use crate::{
 /// [`BasicHeapsConfigure`]: struct.BasicHeapsConfigure.html
 /// [`QueuesConfigure`]: trait.QueuesConfigure.html
 /// [`OneGraphicsQueue`]: struct.OneGraphicsQueue.html
-#[derive(Clone, derivative::Derivative)]
-#[derivative(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Config<D = BasicDevicesConfigure, H = BasicHeapsConfigure, Q = OneGraphicsQueue> {
     /// Config to choose adapter.

--- a/factory/src/factory.rs
+++ b/factory/src/factory.rs
@@ -32,8 +32,7 @@ use {
     thread_profiler::profile_scope,
 };
 
-#[derive(Debug, derivative::Derivative)]
-#[derivative(Default(bound = ""))]
+#[derive(Debug)]
 struct ResourceHub<B: Backend> {
     buffers: ResourceTracker<Buffer<B>>,
     images: ResourceTracker<Image<B>>,
@@ -42,6 +41,23 @@ struct ResourceHub<B: Backend> {
     sets: ResourceTracker<DescriptorSet<B>>,
     samplers: ResourceTracker<Sampler<B>>,
     samplers_cache: parking_lot::RwLock<SamplerCache<B>>,
+}
+
+impl<B> Default for ResourceHub<B>
+where
+    B: Backend,
+{
+    fn default() -> Self {
+        ResourceHub {
+            buffers: ResourceTracker::default(),
+            images: ResourceTracker::default(),
+            views: ResourceTracker::default(),
+            layouts: ResourceTracker::default(),
+            sets: ResourceTracker::default(),
+            samplers: ResourceTracker::default(),
+            samplers_cache: parking_lot::RwLock::new(SamplerCache::default()),
+        }
+    }
 }
 
 impl<B> ResourceHub<B>
@@ -96,6 +112,7 @@ pub enum UploadError {
     Upload(OutOfMemory),
 }
 
+#[derive(Debug)]
 enum InstanceOrId<B: Backend> {
     Instance(Instance<B>),
     Id(InstanceId),
@@ -122,8 +139,7 @@ where
 
 /// Higher level device interface.
 /// Manges memory, resources and queue families.
-#[derive(derivative::Derivative)]
-#[derivative(Debug)]
+#[derive(Debug)]
 pub struct Factory<B: Backend> {
     descriptor_allocator: ManuallyDrop<parking_lot::Mutex<DescriptorAllocator<B>>>,
     heaps: ManuallyDrop<parking_lot::Mutex<Heaps<B>>>,
@@ -132,11 +148,8 @@ pub struct Factory<B: Backend> {
     uploader: Uploader<B>,
     blitter: Blitter<B>,
     families_indices: Vec<usize>,
-    #[derivative(Debug = "ignore")]
     device: Device<B>,
-    #[derivative(Debug = "ignore")]
     adapter: Adapter<B>,
-    #[derivative(Debug = "ignore")]
     instance: InstanceOrId<B>,
 }
 

--- a/frame/Cargo.toml
+++ b/frame/Cargo.toml
@@ -21,7 +21,6 @@ rendy-memory = { version = "0.5.0", path = "../memory" }
 rendy-resource = { version = "0.5.0", path = "../resource" }
 rendy-core = { version = "0.5.0", path = "../core" }
 
-derivative = "1.0"
 either = "1.5"
 log = "0.4"
 relevant = { version = "0.4", features = ["log", "backtrace"] }

--- a/frame/src/cirque/mod.rs
+++ b/frame/src/cirque/mod.rs
@@ -114,13 +114,23 @@ impl<'a, T, I, P> ReadyRef<'a, T, I, P> {
 /// Resource cirque.
 /// It simplifies using multiple resources
 /// when same resource cannot be used simulteneously.
-#[derive(Debug, derivative::Derivative)]
-#[derivative(Default(bound = ""))]
+#[derive(Debug)]
 pub struct Cirque<T, I = T, P = T> {
     pending: VecDeque<(P, usize, Frame)>,
     ready: VecDeque<(T, usize)>,
     marker: std::marker::PhantomData<fn() -> I>,
     counter: usize,
+}
+
+impl<T, I, P> Default for Cirque<T, I, P> {
+    fn default() -> Self {
+        Cirque {
+            pending: VecDeque::default(),
+            ready: VecDeque::default(),
+            marker: std::marker::PhantomData,
+            counter: usize::default(),
+        }
+    }
 }
 
 impl<T, I, P> Cirque<T, I, P> {
@@ -181,9 +191,17 @@ impl<T, I, P> Cirque<T, I, P> {
 /// Resource cirque that depends on another one.
 /// It relies on trusted ready index instead of frame indices.
 /// It guarantees to always return same resource for same index.
-#[derive(Debug, derivative::Derivative)]
-#[derivative(Default(bound = ""))]
+#[derive(Debug)]
 pub struct DependentCirque<T, I = T, P = T> {
     values: Vec<either::Either<T, P>>,
     marker: std::marker::PhantomData<fn() -> I>,
+}
+
+impl<T, I, P> Default for DependentCirque<T, I, P> {
+    fn default() -> Self {
+        DependentCirque {
+            values: Vec::default(),
+            marker: std::marker::PhantomData,
+        }
+    }
 }

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -33,7 +33,6 @@ rendy-shader = { version = "0.5.0", path = "../shader" }
 
 either = "1.5"
 bitflags = "1.0"
-derivative = "1.0"
 log = "0.4"
 relevant = { version = "0.4", features = ["log", "backtrace"] }
 serde = { version = "1.0", optional = true, features = ["derive"] }

--- a/graph/src/graph/mod.rs
+++ b/graph/src/graph/mod.rs
@@ -290,13 +290,41 @@ where
 }
 
 /// Build graph from nodes and resource.
-#[derive(derivative::Derivative)]
-#[derivative(Debug(bound = ""))]
 pub struct GraphBuilder<B: Backend, T: ?Sized> {
     nodes: Vec<Box<dyn NodeBuilder<B, T>>>,
     buffers: Vec<BufferInfo>,
     images: Vec<(ImageInfo, Option<rendy_core::hal::command::ClearValue>)>,
     frames_in_flight: u32,
+}
+
+impl<B, T> Default for GraphBuilder<B, T>
+where
+    B: Backend,
+    T: ?Sized,
+{
+    fn default() -> Self {
+        GraphBuilder {
+            nodes: Vec::default(),
+            buffers: Vec::default(),
+            images: Vec::default(),
+            frames_in_flight: u32::default(),
+        }
+    }
+}
+
+impl<B, T> std::fmt::Debug for GraphBuilder<B, T>
+where
+    B: Backend,
+    T: ?Sized,
+{
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt.debug_struct("GraphBuilder")
+            .field("nodes", &self.nodes)
+            .field("buffers", &self.buffers)
+            .field("images", &self.images)
+            .field("frames_in_flight", &self.frames_in_flight)
+            .finish()
+    }
 }
 
 impl<B, T> GraphBuilder<B, T>

--- a/graph/src/node/mod.rs
+++ b/graph/src/node/mod.rs
@@ -319,14 +319,28 @@ pub trait NodeBuilder<B: Backend, T: ?Sized>: std::fmt::Debug {
 }
 
 /// Builder for the node.
-#[derive(derivative::Derivative)]
-#[derivative(Debug(bound = "N: std::fmt::Debug"))]
 pub struct DescBuilder<B: Backend, T: ?Sized, N> {
     desc: N,
     buffers: Vec<BufferId>,
     images: Vec<ImageId>,
     dependencies: Vec<NodeId>,
     marker: std::marker::PhantomData<fn(B, &T)>,
+}
+
+impl<B, T, N> std::fmt::Debug for DescBuilder<B, T, N>
+where
+    B: Backend,
+    T: ?Sized,
+    N: std::fmt::Debug,
+{
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt.debug_struct("DescBuilder")
+            .field("desc", &self.desc)
+            .field("buffers", &self.buffers)
+            .field("images", &self.images)
+            .field("dependencies", &self.dependencies)
+            .finish()
+    }
 }
 
 impl<B, T, N> DescBuilder<B, T, N>

--- a/graph/src/node/render/pass.rs
+++ b/graph/src/node/render/pass.rs
@@ -33,14 +33,44 @@ struct RenderPassSurface;
 type Attachment = Either<ImageId, RenderPassSurface>;
 
 /// Build for rendering sub-pass.
-#[derive(derivative::Derivative)]
-#[derivative(Default(bound = ""), Debug(bound = ""))]
 pub struct SubpassBuilder<B: Backend, T: ?Sized> {
     groups: Vec<Box<dyn RenderGroupBuilder<B, T>>>,
     inputs: Vec<Attachment>,
     colors: Vec<Attachment>,
     depth_stencil: Option<Attachment>,
     dependencies: Vec<NodeId>,
+}
+
+impl<B, T> std::fmt::Debug for SubpassBuilder<B, T>
+where
+    B: Backend,
+    T: ?Sized,
+{
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt.debug_struct("SubpassBuilder")
+            .field("groups", &self.groups)
+            .field("inputs", &self.inputs)
+            .field("colors", &self.colors)
+            .field("depth_stencil", &self.depth_stencil)
+            .field("dependencies", &self.dependencies)
+            .finish()
+    }
+}
+
+impl<B, T> Default for SubpassBuilder<B, T>
+where
+    B: Backend,
+    T: ?Sized,
+{
+    fn default() -> Self {
+        SubpassBuilder {
+            groups: Vec::default(),
+            inputs: Vec::default(),
+            colors: Vec::default(),
+            depth_stencil: None,
+            dependencies: Vec::default(),
+        }
+    }
 }
 
 impl<B, T> SubpassBuilder<B, T>
@@ -164,8 +194,6 @@ where
 }
 
 /// Builder for render-pass node.
-#[derive(derivative::Derivative)]
-#[derivative(Default(bound = ""), Debug(bound = ""))]
 pub struct RenderPassNodeBuilder<B: Backend, T: ?Sized> {
     subpasses: Vec<SubpassBuilder<B, T>>,
     surface: Option<(
@@ -173,6 +201,32 @@ pub struct RenderPassNodeBuilder<B: Backend, T: ?Sized> {
         rendy_core::hal::window::Extent2D,
         Option<rendy_core::hal::command::ClearValue>,
     )>,
+}
+
+impl<B, T> std::fmt::Debug for RenderPassNodeBuilder<B, T>
+where
+    B: Backend,
+    T: ?Sized,
+{
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt.debug_struct("RenderPassNodeBuilder")
+            .field("subpasses", &self.subpasses)
+            .field("surface", &self.surface)
+            .finish()
+    }
+}
+
+impl<B, T> Default for RenderPassNodeBuilder<B, T>
+where
+    B: Backend,
+    T: ?Sized,
+{
+    fn default() -> Self {
+        RenderPassNodeBuilder {
+            subpasses: Vec::default(),
+            surface: None,
+        }
+    }
 }
 
 impl<B, T> RenderPassNodeBuilder<B, T>
@@ -889,15 +943,23 @@ where
 }
 
 /// Subpass of the `RenderPassNode`.
-#[derive(derivative::Derivative)]
-#[derivative(Debug(bound = ""))]
 struct SubpassNode<B: Backend, T: ?Sized> {
     /// RenderGroups of pipelines to exeucte withing subpass.
     groups: Vec<Box<dyn RenderGroup<B, T>>>,
 }
 
-#[derive(derivative::Derivative)]
-#[derivative(Debug(bound = ""))]
+impl<B, T> std::fmt::Debug for SubpassNode<B, T>
+where
+    B: Backend,
+    T: ?Sized,
+{
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt.debug_struct("SubpassNode")
+            .field("groups", &self.groups)
+            .finish()
+    }
+}
+
 struct BarriersCommands<B: Backend> {
     submit: Submit<B, SimultaneousUse, SecondaryLevel>,
     buffer: CommandBuffer<
@@ -909,8 +971,18 @@ struct BarriersCommands<B: Backend> {
     >,
 }
 
-#[derive(derivative::Derivative)]
-#[derivative(Debug(bound = ""))]
+impl<B> std::fmt::Debug for BarriersCommands<B>
+where
+    B: Backend,
+{
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt.debug_struct("BarriersCommands")
+            .field("submit", &self.submit)
+            .field("buffer", &self.buffer)
+            .finish()
+    }
+}
+
 struct RenderPassNodeCommon<B: Backend, T: ?Sized> {
     subpasses: Vec<SubpassNode<B, T>>,
 
@@ -929,6 +1001,29 @@ struct RenderPassNodeCommon<B: Backend, T: ?Sized> {
     release: Option<BarriersCommands<B>>,
 
     relevant: relevant::Relevant,
+}
+
+impl<B, T> std::fmt::Debug for RenderPassNodeCommon<B, T>
+where
+    B: Backend,
+    T: ?Sized,
+{
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt.debug_struct("RenderPassNodeCommon")
+            .field("subpasses", &self.subpasses)
+            .field("framebuffer_width", &self.framebuffer_width)
+            .field("framebuffer_height", &self.framebuffer_height)
+            .field("_framebuffer_layers", &self._framebuffer_layers)
+            .field("render_pass", &self.render_pass)
+            .field("views", &self.views)
+            .field("clears", &self.clears)
+            .field("command_pool", &self.command_pool)
+            .field("command_cirque", &self.command_cirque)
+            .field("acquire", &self.acquire)
+            .field("release", &self.release)
+            .field("relevant", &self.relevant)
+            .finish()
+    }
 }
 
 impl<B, T> RenderPassNodeCommon<B, T>
@@ -981,13 +1076,26 @@ struct PerImage<B: Backend> {
     index: usize,
 }
 
-#[derive(derivative::Derivative)]
-#[derivative(Debug(bound = ""))]
 struct RenderPassNodeWithSurface<B: Backend, T: ?Sized> {
     common: RenderPassNodeCommon<B, T>,
     per_image: Vec<PerImage<B>>,
     free_acquire: B::Semaphore,
     target: Target<B>,
+}
+
+impl<B, T> std::fmt::Debug for RenderPassNodeWithSurface<B, T>
+where
+    B: Backend,
+    T: ?Sized,
+{
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt.debug_struct("RenderPassNodeWithSurface")
+            .field("common", &self.common)
+            .field("per_image", &self.per_image)
+            .field("free_acquire", &self.free_acquire)
+            .field("target", &self.target)
+            .finish()
+    }
 }
 
 impl<B, T> DynNode<B, T> for RenderPassNodeWithSurface<B, T>
@@ -1171,11 +1279,22 @@ where
     }
 }
 
-#[derive(derivative::Derivative)]
-#[derivative(Debug(bound = ""))]
 struct RenderPassNodeWithoutSurface<B: Backend, T: ?Sized> {
     common: RenderPassNodeCommon<B, T>,
     framebuffer: B::Framebuffer,
+}
+
+impl<B, T> std::fmt::Debug for RenderPassNodeWithoutSurface<B, T>
+where
+    B: Backend,
+    T: ?Sized,
+{
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt.debug_struct("RenderPassNodeWithoutSurface")
+            .field("common", &self.common)
+            .field("framebuffer", &self.framebuffer)
+            .finish()
+    }
 }
 
 impl<B, T> DynNode<B, T> for RenderPassNodeWithoutSurface<B, T>

--- a/memory/Cargo.toml
+++ b/memory/Cargo.toml
@@ -11,11 +11,10 @@ categories = ["rendering"]
 description = "Rendy's memory manager"
 
 [features]
-serde-1 = ["serde", "rendy-core/serde-1"]
+serde-1 = ["serde", "gfx-hal/serde"]
 
 [dependencies]
-rendy-core = { version = "0.5.0", path = "../core" }
-derivative = "1.0"
+gfx-hal = { git = "https://github.com/gfx-rs/gfx", rev = "46386475f7e823e807ec984c372ffe04dcc0a22b" }
 log = "0.4"
 hibitset = {version = "0.6", default-features = false}
 relevant = { version = "0.4", features = ["log", "backtrace"] }

--- a/memory/src/allocator/dedicated.rs
+++ b/memory/src/allocator/dedicated.rs
@@ -7,7 +7,7 @@ use {
         mapping::{mapped_fitting_range, MappedRange},
         memory::*,
     },
-    rendy_core::hal::{device::Device as _, Backend},
+    gfx_hal::{device::Device as _, Backend},
 };
 
 /// Memory block allocated from `DedicatedAllocator`
@@ -45,7 +45,7 @@ where
     B: Backend,
 {
     #[inline]
-    fn properties(&self) -> rendy_core::hal::memory::Properties {
+    fn properties(&self) -> gfx_hal::memory::Properties {
         self.memory.properties()
     }
 
@@ -63,7 +63,7 @@ where
         &'a mut self,
         device: &B::Device,
         range: Range<u64>,
-    ) -> Result<MappedRange<'a, B>, rendy_core::hal::device::MapError> {
+    ) -> Result<MappedRange<'a, B>, gfx_hal::device::MapError> {
         assert!(
             range.start < range.end,
             "Memory mapping region must have valid size"
@@ -71,7 +71,7 @@ where
 
         if !self.memory.host_visible() {
             //TODO: invalid access error
-            return Err(rendy_core::hal::device::MapError::MappingFailed);
+            return Err(gfx_hal::device::MapError::MappingFailed);
         }
 
         unsafe {
@@ -112,22 +112,22 @@ where
 /// TODO: Check if resource prefers dedicated memory.
 #[derive(Debug)]
 pub struct DedicatedAllocator {
-    memory_type: rendy_core::hal::MemoryTypeId,
-    memory_properties: rendy_core::hal::memory::Properties,
+    memory_type: gfx_hal::MemoryTypeId,
+    memory_properties: gfx_hal::memory::Properties,
     used: u64,
 }
 
 impl DedicatedAllocator {
     /// Get properties required by the allocator.
-    pub fn properties_required() -> rendy_core::hal::memory::Properties {
-        rendy_core::hal::memory::Properties::empty()
+    pub fn properties_required() -> gfx_hal::memory::Properties {
+        gfx_hal::memory::Properties::empty()
     }
 
     /// Create new `LinearAllocator`
     /// for `memory_type` with `memory_properties` specified
     pub fn new(
-        memory_type: rendy_core::hal::MemoryTypeId,
-        memory_properties: rendy_core::hal::memory::Properties,
+        memory_type: gfx_hal::MemoryTypeId,
+        memory_properties: gfx_hal::memory::Properties,
     ) -> Self {
         DedicatedAllocator {
             memory_type,
@@ -153,7 +153,7 @@ where
         device: &B::Device,
         size: u64,
         _align: u64,
-    ) -> Result<(DedicatedBlock<B>, u64), rendy_core::hal::device::AllocationError> {
+    ) -> Result<(DedicatedBlock<B>, u64), gfx_hal::device::AllocationError> {
         let memory = unsafe {
             Memory::from_raw(
                 device.allocate_memory(self.memory_type, size)?,

--- a/memory/src/allocator/dynamic.rs
+++ b/memory/src/allocator/dynamic.rs
@@ -13,8 +13,8 @@ use {
         memory::*,
         util::*,
     },
+    gfx_hal::{device::Device as _, Backend},
     hibitset::{BitSet, BitSetLike as _},
-    rendy_core::hal::{device::Device as _, Backend},
 };
 
 /// Memory block allocated from `DynamicAllocator`
@@ -55,7 +55,7 @@ where
     B: Backend,
 {
     #[inline]
-    fn properties(&self) -> rendy_core::hal::memory::Properties {
+    fn properties(&self) -> gfx_hal::memory::Properties {
         self.shared_memory().properties()
     }
 
@@ -74,14 +74,14 @@ where
         &'a mut self,
         _device: &B::Device,
         range: Range<u64>,
-    ) -> Result<MappedRange<'a, B>, rendy_core::hal::device::MapError> {
+    ) -> Result<MappedRange<'a, B>, gfx_hal::device::MapError> {
         debug_assert!(
             range.start < range.end,
             "Memory mapping region must have valid size"
         );
         if !self.shared_memory().host_visible() {
             //TODO: invalid access error
-            return Err(rendy_core::hal::device::MapError::MappingFailed);
+            return Err(gfx_hal::device::MapError::MappingFailed);
         }
 
         if let Some(ptr) = self.ptr {
@@ -89,10 +89,10 @@ where
                 let mapping = unsafe { MappedRange::from_raw(self.shared_memory(), ptr, range) };
                 Ok(mapping)
             } else {
-                Err(rendy_core::hal::device::MapError::OutOfBounds)
+                Err(gfx_hal::device::MapError::OutOfBounds)
             }
         } else {
-            Err(rendy_core::hal::device::MapError::MappingFailed)
+            Err(gfx_hal::device::MapError::MappingFailed)
         }
     }
 
@@ -121,10 +121,10 @@ pub struct DynamicConfig {
 #[derive(Debug)]
 pub struct DynamicAllocator<B: Backend> {
     /// Memory type that this allocator allocates.
-    memory_type: rendy_core::hal::MemoryTypeId,
+    memory_type: gfx_hal::MemoryTypeId,
 
     /// Memory properties of the memory type.
-    memory_properties: rendy_core::hal::memory::Properties,
+    memory_properties: gfx_hal::memory::Properties,
 
     /// All requests are rounded up to multiple of this value.
     block_size_granularity: u64,
@@ -181,8 +181,8 @@ where
     /// for `memory_type` with `memory_properties` specified,
     /// with `DynamicConfig` provided.
     pub fn new(
-        memory_type: rendy_core::hal::MemoryTypeId,
-        memory_properties: rendy_core::hal::memory::Properties,
+        memory_type: gfx_hal::MemoryTypeId,
+        memory_properties: gfx_hal::memory::Properties,
         config: DynamicConfig,
     ) -> Self {
         log::trace!(
@@ -212,7 +212,7 @@ where
             "Min device allocation must be less than or equalt to max chunk size"
         );
 
-        if memory_properties.contains(rendy_core::hal::memory::Properties::CPU_VISIBLE) {
+        if memory_properties.contains(gfx_hal::memory::Properties::CPU_VISIBLE) {
             debug_assert!(
                 fits_usize(config.max_chunk_size),
                 "Max chunk size must fit usize for mapping"
@@ -241,7 +241,7 @@ where
         device: &B::Device,
         block_size: u64,
         chunk_size: u64,
-    ) -> Result<Chunk<B>, rendy_core::hal::device::AllocationError> {
+    ) -> Result<Chunk<B>, gfx_hal::device::AllocationError> {
         log::trace!(
             "Allocate chunk of size: {} for blocks of size {} from device",
             chunk_size,
@@ -255,12 +255,12 @@ where
 
             let mapping = if self
                 .memory_properties
-                .contains(rendy_core::hal::memory::Properties::CPU_VISIBLE)
+                .contains(gfx_hal::memory::Properties::CPU_VISIBLE)
             {
                 log::trace!("Map new memory object");
                 match device.map_memory(&raw, 0..chunk_size) {
                     Ok(mapping) => Some(NonNull::new_unchecked(mapping)),
-                    Err(rendy_core::hal::device::MapError::OutOfMemory(error)) => {
+                    Err(gfx_hal::device::MapError::OutOfMemory(error)) => {
                         device.free_memory(raw);
                         return Err(error.into());
                     }
@@ -281,7 +281,7 @@ where
         device: &B::Device,
         block_size: u64,
         total_blocks: u64,
-    ) -> Result<(Chunk<B>, u64), rendy_core::hal::device::AllocationError> {
+    ) -> Result<(Chunk<B>, u64), gfx_hal::device::AllocationError> {
         log::trace!(
             "Allocate chunk for blocks of size {} ({} total blocks allocated)",
             block_size,
@@ -362,7 +362,7 @@ where
         block_size: u64,
         count: u32,
         align: u64,
-    ) -> Result<(DynamicBlock<B>, u64), rendy_core::hal::device::AllocationError> {
+    ) -> Result<(DynamicBlock<B>, u64), gfx_hal::device::AllocationError> {
         log::trace!(
             "Allocate {} consecutive blocks for size {} from the entry",
             count,
@@ -385,7 +385,7 @@ where
         }
 
         if size_entry.chunks.vacant_entry().key() > max_chunks_per_size() {
-            return Err(rendy_core::hal::device::OutOfMemory::Host.into());
+            return Err(gfx_hal::device::OutOfMemory::Host.into());
         }
 
         let total_blocks = size_entry.total_blocks;
@@ -415,7 +415,7 @@ where
         device: &B::Device,
         block_size: u64,
         align: u64,
-    ) -> Result<(DynamicBlock<B>, u64), rendy_core::hal::device::AllocationError> {
+    ) -> Result<(DynamicBlock<B>, u64), gfx_hal::device::AllocationError> {
         log::trace!("Allocate block of size {}", block_size);
 
         debug_assert_eq!(block_size % self.block_size_granularity, 0);
@@ -455,7 +455,7 @@ where
                 unsafe {
                     if self
                         .memory_properties
-                        .contains(rendy_core::hal::memory::Properties::CPU_VISIBLE)
+                        .contains(gfx_hal::memory::Properties::CPU_VISIBLE)
                     {
                         log::trace!("Unmap memory: {:#?}", boxed);
                         device.unmap_memory(boxed.raw());
@@ -523,7 +523,7 @@ where
         device: &B::Device,
         size: u64,
         align: u64,
-    ) -> Result<(DynamicBlock<B>, u64), rendy_core::hal::device::AllocationError> {
+    ) -> Result<(DynamicBlock<B>, u64), gfx_hal::device::AllocationError> {
         debug_assert!(size <= self.max_allocation());
         debug_assert!(align.is_power_of_two());
         let aligned_size = ((size - 1) | (align - 1) | (self.block_size_granularity - 1)) + 1;

--- a/memory/src/allocator/mod.rs
+++ b/memory/src/allocator/mod.rs
@@ -28,7 +28,7 @@ pub enum Kind {
 }
 
 /// Allocator trait implemented for various allocators.
-pub trait Allocator<B: rendy_core::hal::Backend> {
+pub trait Allocator<B: gfx_hal::Backend> {
     /// Block type returned by allocator.
     type Block: Block<B>;
 
@@ -42,7 +42,7 @@ pub trait Allocator<B: rendy_core::hal::Backend> {
         device: &B::Device,
         size: u64,
         align: u64,
-    ) -> Result<(Self::Block, u64), rendy_core::hal::device::AllocationError>;
+    ) -> Result<(Self::Block, u64), gfx_hal::device::AllocationError>;
 
     /// Free block of memory.
     /// Returns amount of memory returned to the device.

--- a/memory/src/block.rs
+++ b/memory/src/block.rs
@@ -6,9 +6,9 @@ use crate::mapping::MappedRange;
 /// Implementor must ensure that there can't be any other blocks
 /// with overlapping range (either through type system or safety notes for unsafe functions).
 /// Provides access to safe memory range mapping.
-pub trait Block<B: rendy_core::hal::Backend> {
+pub trait Block<B: gfx_hal::Backend> {
     /// Get memory properties of the block.
-    fn properties(&self) -> rendy_core::hal::memory::Properties;
+    fn properties(&self) -> gfx_hal::memory::Properties;
 
     /// Get raw memory object.
     fn memory(&self) -> &B::Memory;
@@ -28,7 +28,7 @@ pub trait Block<B: rendy_core::hal::Backend> {
         &'a mut self,
         device: &B::Device,
         range: Range<u64>,
-    ) -> Result<MappedRange<'a, B>, rendy_core::hal::device::MapError>;
+    ) -> Result<MappedRange<'a, B>, gfx_hal::device::MapError>;
 
     /// Release memory mapping. Must be called after successful `map` call.
     /// No-op if block is not mapped.

--- a/memory/src/heaps/memory_type.rs
+++ b/memory/src/heaps/memory_type.rs
@@ -1,11 +1,11 @@
 use {
     super::{BlockFlavor, HeapsConfig},
     crate::{allocator::*, usage::MemoryUsage, utilization::*},
-    rendy_core::hal::memory::Properties,
+    gfx_hal::memory::Properties,
 };
 
 #[derive(Debug)]
-pub(super) struct MemoryType<B: rendy_core::hal::Backend> {
+pub(super) struct MemoryType<B: gfx_hal::Backend> {
     heap_index: usize,
     properties: Properties,
     dedicated: DedicatedAllocator,
@@ -18,10 +18,10 @@ pub(super) struct MemoryType<B: rendy_core::hal::Backend> {
 
 impl<B> MemoryType<B>
 where
-    B: rendy_core::hal::Backend,
+    B: gfx_hal::Backend,
 {
     pub(super) fn new(
-        memory_type: rendy_core::hal::MemoryTypeId,
+        memory_type: gfx_hal::MemoryTypeId,
         heap_index: usize,
         properties: Properties,
         config: HeapsConfig,
@@ -59,7 +59,7 @@ where
         usage: impl MemoryUsage,
         size: u64,
         align: u64,
-    ) -> Result<(BlockFlavor<B>, u64), rendy_core::hal::device::AllocationError> {
+    ) -> Result<(BlockFlavor<B>, u64), gfx_hal::device::AllocationError> {
         let (block, allocated) = self.alloc_impl(device, usage, size, align)?;
         self.effective += block.size();
         self.used += allocated;
@@ -72,7 +72,7 @@ where
         usage: impl MemoryUsage,
         size: u64,
         align: u64,
-    ) -> Result<(BlockFlavor<B>, u64), rendy_core::hal::device::AllocationError> {
+    ) -> Result<(BlockFlavor<B>, u64), gfx_hal::device::AllocationError> {
         match (self.dynamic.as_mut(), self.linear.as_mut()) {
             (Some(dynamic), Some(linear)) => {
                 if dynamic.max_allocation() >= size

--- a/memory/src/mapping/mod.rs
+++ b/memory/src/mapping/mod.rs
@@ -3,7 +3,7 @@ pub(crate) mod write;
 
 use {
     crate::{memory::Memory, util::fits_usize},
-    rendy_core::hal::{device::Device as _, Backend},
+    gfx_hal::{device::Device as _, Backend},
     std::{ops::Range, ptr::NonNull},
 };
 
@@ -57,7 +57,7 @@ where
     //     memory: &'a Memory<B>,
     //     device: &B::Device,
     //     range: Range<u64>,
-    // ) -> Result<Self, rendy_core::hal::device::MapError> {
+    // ) -> Result<Self, gfx_hal::device::MapError> {
     //     assert!(
     //         range.start < range.end,
     //         "Memory mapping region must have valid size"
@@ -123,7 +123,7 @@ where
         &'b mut self,
         device: &B::Device,
         range: Range<u64>,
-    ) -> Result<&'b [T], rendy_core::hal::device::MapError>
+    ) -> Result<&'b [T], gfx_hal::device::MapError>
     where
         'a: 'b,
         T: Copy,
@@ -138,7 +138,7 @@ where
         );
 
         let (ptr, range) = mapped_sub_range(self.ptr, self.range.clone(), range)
-            .ok_or_else(|| rendy_core::hal::device::MapError::OutOfBounds)?;
+            .ok_or_else(|| gfx_hal::device::MapError::OutOfBounds)?;
 
         let size = (range.end - range.start) as usize;
 
@@ -161,7 +161,7 @@ where
         &'b mut self,
         device: &'b B::Device,
         range: Range<u64>,
-    ) -> Result<impl Write<T> + 'b, rendy_core::hal::device::MapError>
+    ) -> Result<impl Write<T> + 'b, gfx_hal::device::MapError>
     where
         'a: 'b,
         T: Copy,
@@ -176,7 +176,7 @@ where
         );
 
         let (ptr, range) = mapped_sub_range(self.ptr, self.range.clone(), range)
-            .ok_or_else(|| rendy_core::hal::device::MapError::OutOfBounds)?;
+            .ok_or_else(|| gfx_hal::device::MapError::OutOfBounds)?;
 
         let size = (range.end - range.start) as usize;
 
@@ -263,7 +263,7 @@ where
     pub unsafe fn write<'b, U: 'b>(
         &'b mut self,
         range: Range<u64>,
-    ) -> Result<impl Write<U> + 'b, rendy_core::hal::device::MapError>
+    ) -> Result<impl Write<U> + 'b, gfx_hal::device::MapError>
     where
         U: Copy,
     {
@@ -277,7 +277,7 @@ where
         );
 
         let (ptr, range) = mapped_sub_range(self.ptr, self.range.clone(), range)
-            .ok_or_else(|| rendy_core::hal::device::MapError::OutOfBounds)?;
+            .ok_or_else(|| gfx_hal::device::MapError::OutOfBounds)?;
 
         let size = (range.end - range.start) as usize;
 

--- a/memory/src/memory.rs
+++ b/memory/src/memory.rs
@@ -3,19 +3,19 @@
 /// Memory object wrapper.
 /// Contains size and properties of the memory.
 #[derive(Debug)]
-pub struct Memory<B: rendy_core::hal::Backend> {
+pub struct Memory<B: gfx_hal::Backend> {
     raw: B::Memory,
     size: u64,
-    properties: rendy_core::hal::memory::Properties,
+    properties: gfx_hal::memory::Properties,
     relevant: relevant::Relevant,
 }
 
 impl<B> Memory<B>
 where
-    B: rendy_core::hal::Backend,
+    B: gfx_hal::Backend,
 {
     /// Get memory properties.
-    pub fn properties(&self) -> rendy_core::hal::memory::Properties {
+    pub fn properties(&self) -> gfx_hal::memory::Properties {
         self.properties
     }
 
@@ -43,7 +43,7 @@ where
     pub unsafe fn from_raw(
         raw: B::Memory,
         size: u64,
-        properties: rendy_core::hal::memory::Properties,
+        properties: gfx_hal::memory::Properties,
     ) -> Self {
         Memory {
             properties,
@@ -57,14 +57,14 @@ where
     /// `memory.host_visible()` is equivalent to `memory.properties().contains(Properties::CPU_VISIBLE)`
     pub fn host_visible(&self) -> bool {
         self.properties
-            .contains(rendy_core::hal::memory::Properties::CPU_VISIBLE)
+            .contains(gfx_hal::memory::Properties::CPU_VISIBLE)
     }
 
     /// Check if this memory is host-coherent and doesn't require invalidating or flushing.
     /// `memory.host_coherent()` is equivalent to `memory.properties().contains(Properties::COHERENT)`
     pub fn host_coherent(&self) -> bool {
         self.properties
-            .contains(rendy_core::hal::memory::Properties::COHERENT)
+            .contains(gfx_hal::memory::Properties::COHERENT)
     }
 }
 

--- a/memory/src/usage.rs
+++ b/memory/src/usage.rs
@@ -6,14 +6,14 @@ use crate::allocator::Kind;
 /// Memory usage trait.
 pub trait MemoryUsage: std::fmt::Debug {
     /// Get set of properties required for the usage.
-    fn properties_required(&self) -> rendy_core::hal::memory::Properties;
+    fn properties_required(&self) -> gfx_hal::memory::Properties;
 
     /// Get comparable fitness value for memory properties.
     ///
     /// # Panics
     ///
     /// This function will panic if properties set doesn't contain required properties.
-    fn memory_fitness(&self, properties: rendy_core::hal::memory::Properties) -> u32;
+    fn memory_fitness(&self, properties: gfx_hal::memory::Properties) -> u32;
 
     /// Get comparable fitness value for memory allocator.
     fn allocator_fitness(&self, kind: Kind) -> u32;
@@ -24,10 +24,10 @@ where
     T: std::ops::Deref + std::fmt::Debug,
     T::Target: MemoryUsage,
 {
-    fn properties_required(&self) -> rendy_core::hal::memory::Properties {
+    fn properties_required(&self) -> gfx_hal::memory::Properties {
         (&**self).properties_required()
     }
-    fn memory_fitness(&self, properties: rendy_core::hal::memory::Properties) -> u32 {
+    fn memory_fitness(&self, properties: gfx_hal::memory::Properties) -> u32 {
         (&**self).memory_fitness(properties)
     }
     fn allocator_fitness(&self, kind: Kind) -> u32 {
@@ -42,18 +42,17 @@ where
 pub struct Data;
 
 impl MemoryUsage for Data {
-    fn properties_required(&self) -> rendy_core::hal::memory::Properties {
-        rendy_core::hal::memory::Properties::DEVICE_LOCAL
+    fn properties_required(&self) -> gfx_hal::memory::Properties {
+        gfx_hal::memory::Properties::DEVICE_LOCAL
     }
 
     #[inline]
-    fn memory_fitness(&self, properties: rendy_core::hal::memory::Properties) -> u32 {
-        assert!(properties.contains(rendy_core::hal::memory::Properties::DEVICE_LOCAL));
-        0 | ((!properties.contains(rendy_core::hal::memory::Properties::CPU_VISIBLE)) as u32) << 3
-            | ((!properties.contains(rendy_core::hal::memory::Properties::LAZILY_ALLOCATED)) as u32)
-                << 2
-            | ((!properties.contains(rendy_core::hal::memory::Properties::CPU_CACHED)) as u32) << 1
-            | ((!properties.contains(rendy_core::hal::memory::Properties::COHERENT)) as u32) << 0
+    fn memory_fitness(&self, properties: gfx_hal::memory::Properties) -> u32 {
+        assert!(properties.contains(gfx_hal::memory::Properties::DEVICE_LOCAL));
+        0 | ((!properties.contains(gfx_hal::memory::Properties::CPU_VISIBLE)) as u32) << 3
+            | ((!properties.contains(gfx_hal::memory::Properties::LAZILY_ALLOCATED)) as u32) << 2
+            | ((!properties.contains(gfx_hal::memory::Properties::CPU_CACHED)) as u32) << 1
+            | ((!properties.contains(gfx_hal::memory::Properties::COHERENT)) as u32) << 0
     }
 
     fn allocator_fitness(&self, kind: Kind) -> u32 {
@@ -73,18 +72,18 @@ impl MemoryUsage for Data {
 pub struct Dynamic;
 
 impl MemoryUsage for Dynamic {
-    fn properties_required(&self) -> rendy_core::hal::memory::Properties {
-        rendy_core::hal::memory::Properties::CPU_VISIBLE
+    fn properties_required(&self) -> gfx_hal::memory::Properties {
+        gfx_hal::memory::Properties::CPU_VISIBLE
     }
 
     #[inline]
-    fn memory_fitness(&self, properties: rendy_core::hal::memory::Properties) -> u32 {
-        assert!(properties.contains(rendy_core::hal::memory::Properties::CPU_VISIBLE));
-        assert!(!properties.contains(rendy_core::hal::memory::Properties::LAZILY_ALLOCATED));
+    fn memory_fitness(&self, properties: gfx_hal::memory::Properties) -> u32 {
+        assert!(properties.contains(gfx_hal::memory::Properties::CPU_VISIBLE));
+        assert!(!properties.contains(gfx_hal::memory::Properties::LAZILY_ALLOCATED));
 
-        0 | (properties.contains(rendy_core::hal::memory::Properties::DEVICE_LOCAL) as u32) << 2
-            | (properties.contains(rendy_core::hal::memory::Properties::COHERENT) as u32) << 1
-            | ((!properties.contains(rendy_core::hal::memory::Properties::CPU_CACHED)) as u32) << 0
+        0 | (properties.contains(gfx_hal::memory::Properties::DEVICE_LOCAL) as u32) << 2
+            | (properties.contains(gfx_hal::memory::Properties::COHERENT) as u32) << 1
+            | ((!properties.contains(gfx_hal::memory::Properties::CPU_CACHED)) as u32) << 0
     }
 
     fn allocator_fitness(&self, kind: Kind) -> u32 {
@@ -103,18 +102,18 @@ impl MemoryUsage for Dynamic {
 pub struct Upload;
 
 impl MemoryUsage for Upload {
-    fn properties_required(&self) -> rendy_core::hal::memory::Properties {
-        rendy_core::hal::memory::Properties::CPU_VISIBLE
+    fn properties_required(&self) -> gfx_hal::memory::Properties {
+        gfx_hal::memory::Properties::CPU_VISIBLE
     }
 
     #[inline]
-    fn memory_fitness(&self, properties: rendy_core::hal::memory::Properties) -> u32 {
-        assert!(properties.contains(rendy_core::hal::memory::Properties::CPU_VISIBLE));
-        assert!(!properties.contains(rendy_core::hal::memory::Properties::LAZILY_ALLOCATED));
+    fn memory_fitness(&self, properties: gfx_hal::memory::Properties) -> u32 {
+        assert!(properties.contains(gfx_hal::memory::Properties::CPU_VISIBLE));
+        assert!(!properties.contains(gfx_hal::memory::Properties::LAZILY_ALLOCATED));
 
-        0 | ((!properties.contains(rendy_core::hal::memory::Properties::DEVICE_LOCAL)) as u32) << 2
-            | (properties.contains(rendy_core::hal::memory::Properties::COHERENT) as u32) << 1
-            | ((!properties.contains(rendy_core::hal::memory::Properties::CPU_CACHED)) as u32) << 0
+        0 | ((!properties.contains(gfx_hal::memory::Properties::DEVICE_LOCAL)) as u32) << 2
+            | (properties.contains(gfx_hal::memory::Properties::COHERENT) as u32) << 1
+            | ((!properties.contains(gfx_hal::memory::Properties::CPU_CACHED)) as u32) << 0
     }
 
     fn allocator_fitness(&self, kind: Kind) -> u32 {
@@ -133,18 +132,18 @@ impl MemoryUsage for Upload {
 pub struct Download;
 
 impl MemoryUsage for Download {
-    fn properties_required(&self) -> rendy_core::hal::memory::Properties {
-        rendy_core::hal::memory::Properties::CPU_VISIBLE
+    fn properties_required(&self) -> gfx_hal::memory::Properties {
+        gfx_hal::memory::Properties::CPU_VISIBLE
     }
 
     #[inline]
-    fn memory_fitness(&self, properties: rendy_core::hal::memory::Properties) -> u32 {
-        assert!(properties.contains(rendy_core::hal::memory::Properties::CPU_VISIBLE));
-        assert!(!properties.contains(rendy_core::hal::memory::Properties::LAZILY_ALLOCATED));
+    fn memory_fitness(&self, properties: gfx_hal::memory::Properties) -> u32 {
+        assert!(properties.contains(gfx_hal::memory::Properties::CPU_VISIBLE));
+        assert!(!properties.contains(gfx_hal::memory::Properties::LAZILY_ALLOCATED));
 
-        0 | ((!properties.contains(rendy_core::hal::memory::Properties::DEVICE_LOCAL)) as u32) << 2
-            | (properties.contains(rendy_core::hal::memory::Properties::CPU_CACHED) as u32) << 1
-            | (properties.contains(rendy_core::hal::memory::Properties::COHERENT) as u32) << 0
+        0 | ((!properties.contains(gfx_hal::memory::Properties::DEVICE_LOCAL)) as u32) << 2
+            | (properties.contains(gfx_hal::memory::Properties::CPU_CACHED) as u32) << 1
+            | (properties.contains(gfx_hal::memory::Properties::COHERENT) as u32) << 0
     }
 
     fn allocator_fitness(&self, kind: Kind) -> u32 {
@@ -182,7 +181,7 @@ pub enum MemoryUsageValue {
 
 /// Memory usage trait.
 impl MemoryUsage for MemoryUsageValue {
-    fn properties_required(&self) -> rendy_core::hal::memory::Properties {
+    fn properties_required(&self) -> gfx_hal::memory::Properties {
         match self {
             MemoryUsageValue::Data => Data.properties_required(),
             MemoryUsageValue::Dynamic => Dynamic.properties_required(),
@@ -191,7 +190,7 @@ impl MemoryUsage for MemoryUsageValue {
         }
     }
 
-    fn memory_fitness(&self, properties: rendy_core::hal::memory::Properties) -> u32 {
+    fn memory_fitness(&self, properties: gfx_hal::memory::Properties) -> u32 {
         match self {
             MemoryUsageValue::Data => Data.memory_fitness(properties),
             MemoryUsageValue::Dynamic => Dynamic.memory_fitness(properties),

--- a/memory/src/utilization.rs
+++ b/memory/src/utilization.rs
@@ -1,6 +1,6 @@
 use {
     colorful::{core::color_string::CString, Color, Colorful as _},
-    rendy_core::hal::memory::Properties,
+    gfx_hal::memory::Properties,
 };
 
 /// Memory utilization stats.

--- a/resource/Cargo.toml
+++ b/resource/Cargo.toml
@@ -15,7 +15,6 @@ no-slow-safety-checks = ["rendy-core/no-slow-safety-checks"]
 
 [dependencies]
 crossbeam-channel = "0.3"
-derivative = "1.0"
 log = "0.4"
 relevant = { version = "0.4", features = ["log", "backtrace"] }
 rendy-descriptor = { version = "0.5.0", path = "../descriptor" }

--- a/resource/src/escape.rs
+++ b/resource/src/escape.rs
@@ -161,7 +161,7 @@ pub struct Handle<T> {
 impl<T> Clone for Handle<T> {
     fn clone(&self) -> Self {
         Handle {
-            inner: self.inner.clone()
+            inner: self.inner.clone(),
         }
     }
 }

--- a/resource/src/escape.rs
+++ b/resource/src/escape.rs
@@ -153,10 +153,17 @@ impl<T> Drop for Terminal<T> {
 /// Permit sharing unlike [`Escape`]
 ///
 /// [`Escape`]: ./struct.Escape.html
-#[derive(derivative::Derivative, Debug)]
-#[derivative(Clone(bound = ""))]
+#[derive(Debug)]
 pub struct Handle<T> {
     inner: Arc<Escape<T>>,
+}
+
+impl<T> Clone for Handle<T> {
+    fn clone(&self) -> Self {
+        Handle {
+            inner: self.inner.clone()
+        }
+    }
 }
 
 impl<T> From<Escape<T>> for Handle<T> {

--- a/resource/src/resources.rs
+++ b/resource/src/resources.rs
@@ -23,11 +23,19 @@ impl Epochs {
 }
 
 /// Resource handler.
-#[derive(Debug, derivative::Derivative)]
-#[derivative(Default(bound = ""))]
+#[derive(Debug)]
 pub struct ResourceTracker<T> {
     terminal: Terminal<T>,
     dropped: VecDeque<(Epochs, T)>,
+}
+
+impl<T> Default for ResourceTracker<T> {
+    fn default() -> Self {
+        ResourceTracker {
+            terminal: Terminal::default(),
+            dropped: VecDeque::default(),
+        }
+    }
 }
 
 impl<T> ResourceTracker<T> {

--- a/resource/src/sampler/cache.rs
+++ b/resource/src/sampler/cache.rs
@@ -11,10 +11,20 @@ use {
 };
 
 /// Sampler cache holds handlers to created samplers.
-#[derive(Debug, derivative::Derivative)]
-#[derivative(Default(bound = ""))]
+#[derive(Debug)]
 pub struct SamplerCache<B: Backend> {
     samplers: HashMap<SamplerDesc, Handle<Sampler<B>>>,
+}
+
+impl<B> Default for SamplerCache<B>
+where
+    B: Backend,
+{
+    fn default() -> Self {
+        SamplerCache {
+            samplers: HashMap::default(),
+        }
+    }
 }
 
 impl<B> SamplerCache<B>

--- a/shader/Cargo.toml
+++ b/shader/Cargo.toml
@@ -17,7 +17,6 @@ serde-1 = ["serde", "rendy-core/serde-1"]
 
 [dependencies]
 smallvec = "0.6"
-derivative = "1.0"
 log = "0.4"
 rendy-factory = { version = "0.5.0", path = "../factory" }
 rendy-core = { version = "0.5.0", path = "../core" }

--- a/shader/src/lib.rs
+++ b/shader/src/lib.rs
@@ -147,10 +147,20 @@ impl Shader for SpirvShader {
 }
 
 /// A `ShaderSet` object represents a merged collection of `ShaderStorage` structures, which reflects merged information for all shaders in the set.
-#[derive(derivative::Derivative, Debug)]
-#[derivative(Default(bound = ""))]
+#[derive(Debug)]
 pub struct ShaderSet<B: Backend> {
     shaders: HashMap<ShaderStageFlags, ShaderStorage<B>>,
+}
+
+impl<B> Default for ShaderSet<B>
+where
+    B: Backend,
+{
+    fn default() -> Self {
+        ShaderSet {
+            shaders: HashMap::default()
+        }
+    }
 }
 
 impl<B: Backend> ShaderSet<B> {
@@ -169,7 +179,7 @@ impl<B: Backend> ShaderSet<B> {
     /// Returns the `GraphicsShaderSet` structure to provide all the runtime information needed to use the shaders in this set in rendy_core::hal.
     pub fn raw<'a>(
         &'a self,
-    ) -> Result<(rendy_core::hal::pso::GraphicsShaderSet<'a, B>), ShaderError> {
+    ) -> Result<rendy_core::hal::pso::GraphicsShaderSet<'a, B>, ShaderError> {
         Ok(rendy_core::hal::pso::GraphicsShaderSet {
             vertex: self
                 .shaders

--- a/shader/src/lib.rs
+++ b/shader/src/lib.rs
@@ -158,7 +158,7 @@ where
 {
     fn default() -> Self {
         ShaderSet {
-            shaders: HashMap::default()
+            shaders: HashMap::default(),
         }
     }
 }

--- a/shader/src/reflect/mod.rs
+++ b/shader/src/reflect/mod.rs
@@ -93,7 +93,7 @@ impl From<ReflectTypeError> for ReflectError {
 
 #[derive(Clone, Debug)]
 pub(crate) struct SpirvCachedGfxDescription {
-    pub vertices: (Vec<(u32, String, u8, rendy_core::hal::format::Format)>),
+    pub vertices: Vec<(u32, String, u8, rendy_core::hal::format::Format)>,
     pub layout: Layout,
 }
 

--- a/texture/Cargo.toml
+++ b/texture/Cargo.toml
@@ -21,7 +21,6 @@ rendy-resource = { version = "0.5.0", path = "../resource" }
 rendy-factory = { version = "0.5.0", path = "../factory" }
 rendy-core = { version = "0.5.0", path = "../core" }
 
-derivative = "1.0"
 serde = { version = "1.0", optional = true }
 image = { version = "0.22.0", optional = true }
 palette = { version = "0.4", optional = true }

--- a/texture/src/format/image.rs
+++ b/texture/src/format/image.rs
@@ -41,16 +41,10 @@ pub enum TextureKind {
     D1,
     D1Array,
     D2,
-    D2Array {
-        layers: u16,
-    },
-    D3 {
-        depth: u32,
-    },
+    D2Array { layers: u16 },
+    D3 { depth: u32 },
     Cube,
-    CubeArray {
-        layers: u16,
-    },
+    CubeArray { layers: u16 },
 }
 
 impl Default for TextureKind {
@@ -118,7 +112,10 @@ impl Default for ImageTextureConfig {
             format: None,
             repr: Repr::default(),
             kind: TextureKind::default(),
-            sampler_info: rendy_core::hal::image::SamplerDesc::new(rendy_core::hal::image::Filter::Linear, rendy_core::hal::image::WrapMode::Clamp),
+            sampler_info: rendy_core::hal::image::SamplerDesc::new(
+                rendy_core::hal::image::Filter::Linear,
+                rendy_core::hal::image::WrapMode::Clamp,
+            ),
             generate_mips: false,
             premultiply_alpha: false,
         }

--- a/texture/src/format/image.rs
+++ b/texture/src/format/image.rs
@@ -1,16 +1,14 @@
 //! Module that turns an image into a `Texture`
 
 use crate::{pixel, MipLevels, TextureBuilder};
-use derivative::Derivative;
 
 use std::num::NonZeroU8;
 
 // reexport for easy usage in ImageTextureConfig
 pub use image::ImageFormat;
 
-#[derive(Derivative, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derivative(Default)]
 pub enum Repr {
     Float,
     Unorm,
@@ -19,8 +17,13 @@ pub enum Repr {
     Iscaled,
     Uint,
     Int,
-    #[derivative(Default)]
     Srgb,
+}
+
+impl Default for Repr {
+    fn default() -> Self {
+        Repr::Srgb
+    }
 }
 
 /// A description how to interpret loaded texture.
@@ -32,13 +35,11 @@ pub enum Repr {
 ///
 /// 1D arrays are treated as a sequence of rows, each being an array entry.
 /// 1D images are treated as a single sequence of pixels.
-#[derive(Derivative, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derivative(Default)]
 pub enum TextureKind {
     D1,
     D1Array,
-    #[derivative(Default)]
     D2,
     D2Array {
         layers: u16,
@@ -50,6 +51,12 @@ pub enum TextureKind {
     CubeArray {
         layers: u16,
     },
+}
+
+impl Default for TextureKind {
+    fn default() -> Self {
+        TextureKind::D2
+    }
 }
 
 impl TextureKind {
@@ -82,13 +89,12 @@ impl TextureKind {
     }
 }
 
-#[derive(Derivative, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(
     feature = "serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(default)
 )]
-#[derivative(Default)]
 pub struct ImageTextureConfig {
     /// Interpret the image as given format.
     /// When `None`, format is determined automatically based on magic bytes.
@@ -97,18 +103,26 @@ pub struct ImageTextureConfig {
     pub format: Option<ImageFormat>,
     pub repr: Repr,
     pub kind: TextureKind,
-    #[derivative(Default(
-        value = "rendy_core::hal::image::SamplerDesc::new(rendy_core::hal::image::Filter::Linear, rendy_core::hal::image::WrapMode::Clamp)"
-    ))]
     pub sampler_info: rendy_core::hal::image::SamplerDesc,
-    #[derivative(Default(value = "false"))]
     /// Automatically generate mipmaps for this image
     pub generate_mips: bool,
-    #[derivative(Default(value = "false"))]
     /// Premultiply the alpha channel of the image, if there is one. Note that this
     /// means an image stored with non-premultiplied alpha will become premultiplied,
     /// rather than indicating that the supplied image is premultiplied to begin with.
     pub premultiply_alpha: bool,
+}
+
+impl Default for ImageTextureConfig {
+    fn default() -> Self {
+        ImageTextureConfig {
+            format: None,
+            repr: Repr::default(),
+            kind: TextureKind::default(),
+            sampler_info: rendy_core::hal::image::SamplerDesc::new(rendy_core::hal::image::Filter::Linear, rendy_core::hal::image::WrapMode::Clamp),
+            generate_mips: false,
+            premultiply_alpha: false,
+        }
+    }
 }
 
 #[cfg(feature = "serde")]

--- a/texture/src/pixel.rs
+++ b/texture/src/pixel.rs
@@ -208,15 +208,6 @@ impl_pixel_repr! {
 }
 
 /// One pixel
-/// By default deriving X adds T: X bound for all type parameters for the type.
-/// We use `derivative` here to override that.
-#[derive(derivative::Derivative)]
-#[derivative(
-    Clone(bound = ""),
-    Copy(bound = ""),
-    Debug(bound = ""),
-    Default(bound = "")
-)]
 #[repr(transparent)]
 pub struct Pixel<C, S, T>
 where
@@ -224,6 +215,44 @@ where
 {
     /// Pixel representation.
     pub repr: <C as PixelRepr<S, T>>::Repr,
+}
+
+impl<C, S, T> Copy for Pixel<C, S, T>
+where
+    C: PixelRepr<S, T>,
+{}
+
+impl<C, S, T> Clone for Pixel<C, S, T>
+where
+    C: PixelRepr<S, T>,
+{
+    fn clone(&self) -> Self {
+        Pixel {
+            repr: self.repr.clone()
+        }
+    }
+}
+
+impl<C, S, T> std::fmt::Debug for Pixel<C, S, T>
+where
+    C: PixelRepr<S, T>,
+{
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt.debug_struct("Pixel")
+            .field("repr", &self.repr)
+            .finish()
+    }
+}
+
+impl<C, S, T> Default for Pixel<C, S, T>
+where
+    C: PixelRepr<S, T>,
+{
+    fn default() -> Self {
+        Pixel {
+            repr: C::Repr::default()
+        }
+    }
 }
 
 /// AsPixel trait for extracting the underlying data representation information from a Rust data type

--- a/texture/src/pixel.rs
+++ b/texture/src/pixel.rs
@@ -217,10 +217,7 @@ where
     pub repr: <C as PixelRepr<S, T>>::Repr,
 }
 
-impl<C, S, T> Copy for Pixel<C, S, T>
-where
-    C: PixelRepr<S, T>,
-{}
+impl<C, S, T> Copy for Pixel<C, S, T> where C: PixelRepr<S, T> {}
 
 impl<C, S, T> Clone for Pixel<C, S, T>
 where
@@ -228,7 +225,7 @@ where
 {
     fn clone(&self) -> Self {
         Pixel {
-            repr: self.repr.clone()
+            repr: self.repr.clone(),
         }
     }
 }
@@ -238,9 +235,7 @@ where
     C: PixelRepr<S, T>,
 {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        fmt.debug_struct("Pixel")
-            .field("repr", &self.repr)
-            .finish()
+        fmt.debug_struct("Pixel").field("repr", &self.repr).finish()
     }
 }
 
@@ -250,7 +245,7 @@ where
 {
     fn default() -> Self {
         Pixel {
-            repr: C::Repr::default()
+            repr: C::Repr::default(),
         }
     }
 }

--- a/texture/src/texture.rs
+++ b/texture/src/texture.rs
@@ -10,7 +10,6 @@ use {
             ImageViewCreationError, ImageViewInfo, Sampler,
         },
     },
-    derivative::Derivative,
     rendy_core::hal::{
         format::{Component, Format, Swizzle},
         image, Backend,
@@ -90,15 +89,13 @@ pub enum BuildError {
 }
 
 /// Generics-free texture builder.
-#[derive(Clone, Derivative)]
-#[derivative(Debug)]
+#[derive(Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// Struct for staging data in preparation of building a `Texture`
 pub struct TextureBuilder<'a> {
     kind: image::Kind,
     view_kind: image::ViewKind,
     format: Format,
-    #[derivative(Debug = "ignore")]
     data: std::borrow::Cow<'a, [u8]>,
     data_width: u32,
     data_height: u32,
@@ -106,6 +103,23 @@ pub struct TextureBuilder<'a> {
     swizzle: Swizzle,
     mip_levels: MipLevels,
     premultiplied: bool,
+}
+
+impl<'a> std::fmt::Debug for TextureBuilder<'a> {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt.debug_struct("TextureBuilder")
+            .field("kind", &self.kind)
+            .field("view_kind", &self.view_kind)
+            .field("format", &self.format)
+            .field("data", &"<raw-data>")
+            .field("data_width", &self.data_width)
+            .field("data_height", &self.data_height)
+            .field("sampler_info", &self.sampler_info)
+            .field("swizzle", &self.swizzle)
+            .field("mip_levels", &self.mip_levels)
+            .field("premultiplied", &self.premultiplied)
+            .finish()
+    }
 }
 
 impl<'a> TextureBuilder<'a> {

--- a/wsi/Cargo.toml
+++ b/wsi/Cargo.toml
@@ -23,7 +23,6 @@ rendy-memory = { version = "0.5.0", path = "../memory" }
 rendy-resource = { version = "0.5.0", path = "../resource" }
 rendy-core = { version = "0.5.0", path = "../core" }
 
-derivative = "1.0"
 log = "0.4"
 relevant = { version = "0.4", features = ["log", "backtrace"] }
 smallvec = "0.6"


### PR DESCRIPTION
As those crates don't actually use `rendy-core` (which compiles too long for its content) we can reduce build time for those who don't use full `rendy`.
Also removing `derivative` and transitively another version of `syn` from deps tree.