### PR TITLE
Match amethyst `rand_core` dependencies

### DIFF
--- a/texture/Cargo.toml
+++ b/texture/Cargo.toml
@@ -23,6 +23,6 @@ rendy-core = { version = "0.5.1", path = "../core" }
 
 serde = { version = "1.0", optional = true }
 image = { version = "0.22.0", optional = true }
-palette = { version = "0.4", optional = true }
+palette = { version = "0.5", optional = true }
 log = "0.4"
 thread_profiler = "0.3"


### PR DESCRIPTION
`palette` includes an earlier version of rand/rand_core, which is incompatible with the version used in Amethyst. This breaks example code (using the following toolchains)

stable-x86_64-apple-darwin - Up to date : 1.42.0 (b8cedc004 2020-03-09)
nightly-x86_64-apple-darwin - Up to date : 1.44.0-nightly (7ceebd98c 2020-03-17)

This also needs an update to the palette deps in amethyst and amethest_rendy