### PR TITLE
Remove wgpu-rs from users in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ enabled separately (enabling a subcrate will also enable its dependencies).
 ## Who is using it?
 
 * The [`Amethyst`](https://github.com/amethyst/) project
-* [wgpu-rs](https://github.com/gfx-rs/wgpu-rs)
 
 Kindly open a PR or issue if you're aware of other projects using `rendy`.
 


### PR DESCRIPTION
wgpu-rs is not using rendy as stated in the readme

see:
https://github.com/gfx-rs/wgpu-rs/blob/master/Cargo.toml