### PR TITLE
rendy-util Attribute fix deserialization for binary formats in 0.4.1

### DIFF
--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rendy-chain"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["omni-viral <scareaangel@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/amethyst/rendy"

--- a/command/Cargo.toml
+++ b/command/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rendy-command"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["omni-viral <scareaangel@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/amethyst/rendy"

--- a/descriptor/Cargo.toml
+++ b/descriptor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rendy-descriptor"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["omni-viral <scareaangel@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/amethyst/rendy"

--- a/factory/Cargo.toml
+++ b/factory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rendy-factory"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["omni-viral <scareaangel@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/amethyst/rendy"
@@ -24,12 +24,12 @@ no-slow-safety-checks = ["rendy-util/no-slow-safety-checks"]
 profiler = ["thread_profiler/thread_profiler"]
 
 [dependencies]
-rendy-memory = { version = "0.4.0", path = "../memory" }
-rendy-resource = { version = "0.4.0", path = "../resource" }
-rendy-command = { version = "0.4.0", path = "../command" }
-rendy-descriptor = { version = "0.4.0", path = "../descriptor" }
-rendy-wsi = { version = "0.4.0", path = "../wsi" }
-rendy-util = { version = "0.4.0", path = "../util" }
+rendy-memory = { version = "0.4.1", path = "../memory" }
+rendy-resource = { version = "0.4.1", path = "../resource" }
+rendy-command = { version = "0.4.1", path = "../command" }
+rendy-descriptor = { version = "0.4.1", path = "../descriptor" }
+rendy-wsi = { version = "0.4.1", path = "../wsi" }
+rendy-util = { version = "0.4.1", path = "../util" }
 
 gfx-hal = "0.3"
 derivative = "1.0"

--- a/frame/Cargo.toml
+++ b/frame/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rendy-frame"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["omni-viral <scareaangel@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/amethyst/rendy"
@@ -15,11 +15,11 @@ no-slow-safety-checks = ["rendy-util/no-slow-safety-checks"]
 profiler = ["thread_profiler/thread_profiler"]
 
 [dependencies]
-rendy-command = { version = "0.4.0", path = "../command" }
-rendy-factory = { version = "0.4.0", path = "../factory" }
-rendy-memory = { version = "0.4.0", path = "../memory" }
-rendy-resource = { version = "0.4.0", path = "../resource" }
-rendy-util = { version = "0.4.0", path = "../util" }
+rendy-command = { version = "0.4.1", path = "../command" }
+rendy-factory = { version = "0.4.1", path = "../factory" }
+rendy-memory = { version = "0.4.1", path = "../memory" }
+rendy-resource = { version = "0.4.1", path = "../resource" }
+rendy-util = { version = "0.4.1", path = "../util" }
 
 derivative = "1.0"
 either = "1.5"

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rendy-graph"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["omni-viral <scareaangel@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/amethyst/rendy"
@@ -19,16 +19,16 @@ no-slow-safety-checks = ["rendy-util/no-slow-safety-checks"]
 profiler = ["thread_profiler/thread_profiler"]
 
 [dependencies]
-rendy-chain = { version = "0.4.0", path = "../chain" }
-rendy-command = { version = "0.4.0", path = "../command" }
-rendy-descriptor = { version = "0.4.0", path = "../descriptor" }
-rendy-factory = { version = "0.4.0", path = "../factory" }
-rendy-frame = { version = "0.4.0", path = "../frame" }
-rendy-memory = { version = "0.4.0", path = "../memory" }
-rendy-resource = { version = "0.4.0", path = "../resource" }
-rendy-util = { version = "0.4.0", path = "../util" }
-rendy-wsi = { version = "0.4.0", path = "../wsi" }
-rendy-shader = { version = "0.4.0", path = "../shader" }
+rendy-chain = { version = "0.4.1", path = "../chain" }
+rendy-command = { version = "0.4.1", path = "../command" }
+rendy-descriptor = { version = "0.4.1", path = "../descriptor" }
+rendy-factory = { version = "0.4.1", path = "../factory" }
+rendy-frame = { version = "0.4.1", path = "../frame" }
+rendy-memory = { version = "0.4.1", path = "../memory" }
+rendy-resource = { version = "0.4.1", path = "../resource" }
+rendy-util = { version = "0.4.1", path = "../util" }
+rendy-wsi = { version = "0.4.1", path = "../wsi" }
+rendy-shader = { version = "0.4.1", path = "../shader" }
 
 gfx-hal = "0.3"
 

--- a/memory/Cargo.toml
+++ b/memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rendy-memory"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["omni-viral <scareaangel@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/amethyst/rendy"

--- a/mesh/Cargo.toml
+++ b/mesh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rendy-mesh"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["omni-viral <scareaangel@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/amethyst/rendy"
@@ -17,11 +17,11 @@ serde-1 = ["serde", "serde_bytes", "gfx-hal/serde", "smallvec/serde", "rendy-fac
 no-slow-safety-checks = ["rendy-util/no-slow-safety-checks"]
 
 [dependencies]
-rendy-command = { version = "0.4.0", path = "../command" }
-rendy-memory = { version = "0.4.0", path = "../memory" }
-rendy-resource = { version = "0.4.0", path = "../resource" }
-rendy-factory = { version = "0.4.0", path = "../factory" }
-rendy-util = { version = "0.4.0", path = "../util" }
+rendy-command = { version = "0.4.1", path = "../command" }
+rendy-memory = { version = "0.4.1", path = "../memory" }
+rendy-resource = { version = "0.4.1", path = "../resource" }
+rendy-factory = { version = "0.4.1", path = "../factory" }
+rendy-util = { version = "0.4.1", path = "../util" }
 
 gfx-hal = "0.3"
 

--- a/rendy/Cargo.toml
+++ b/rendy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rendy"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["omni-viral <scareaangel@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/amethyst/rendy"
@@ -54,18 +54,18 @@ full = ["base", "mesh-obj", "texture-image", "texture-palette", "spirv-reflectio
 default = [ "base", "shader-compiler", "spirv-reflection", "wsi-winit" ]
 
 [dependencies]
-rendy-command = { version = "0.4.0", path = "../command", optional = true }
-rendy-descriptor = { version = "0.4.0", path = "../descriptor", optional = true }
-rendy-factory = { version = "0.4.0", path = "../factory", optional = true }
-rendy-frame = { version = "0.4.0", path = "../frame", optional = true }
-rendy-graph = { version = "0.4.0", path = "../graph", optional = true }
-rendy-memory = { version = "0.4.0", path = "../memory", optional = true }
-rendy-mesh = { version = "0.4.0", path = "../mesh", optional = true }
-rendy-shader = { version = "0.4.0", path = "../shader", optional = true }
-rendy-resource = { version = "0.4.0", path = "../resource", optional = true }
-rendy-texture = { version = "0.4.0", path = "../texture", optional = true }
-rendy-util = { version = "0.4.0", path = "../util" }
-rendy-wsi = { version = "0.4.0", path = "../wsi", optional = true }
+rendy-command = { version = "0.4.1", path = "../command", optional = true }
+rendy-descriptor = { version = "0.4.1", path = "../descriptor", optional = true }
+rendy-factory = { version = "0.4.1", path = "../factory", optional = true }
+rendy-frame = { version = "0.4.1", path = "../frame", optional = true }
+rendy-graph = { version = "0.4.1", path = "../graph", optional = true }
+rendy-memory = { version = "0.4.1", path = "../memory", optional = true }
+rendy-mesh = { version = "0.4.1", path = "../mesh", optional = true }
+rendy-shader = { version = "0.4.1", path = "../shader", optional = true }
+rendy-resource = { version = "0.4.1", path = "../resource", optional = true }
+rendy-texture = { version = "0.4.1", path = "../texture", optional = true }
+rendy-util = { version = "0.4.1", path = "../util" }
+rendy-wsi = { version = "0.4.1", path = "../wsi", optional = true }
 
 failure = "0.1"
 gfx-hal = "0.3"

--- a/resource/Cargo.toml
+++ b/resource/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rendy-resource"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["omni-viral <scareaangel@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/amethyst/rendy"
@@ -20,7 +20,7 @@ derivative = "1.0"
 failure = "0.1"
 log = "0.4"
 relevant = { version = "0.4", features = ["log", "backtrace"] }
-rendy-descriptor = { version = "0.4.0", path = "../descriptor" }
-rendy-memory = { version = "0.4.0", path = "../memory" }
-rendy-util = { version = "0.4.0", path = "../util" }
+rendy-descriptor = { version = "0.4.1", path = "../descriptor" }
+rendy-memory = { version = "0.4.1", path = "../memory" }
+rendy-util = { version = "0.4.1", path = "../util" }
 smallvec = "0.6"

--- a/shader/Cargo.toml
+++ b/shader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rendy-shader"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["omni-viral <scareaangel@gmail.com>", "Walter Pearce <jaynus@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/amethyst/rendy"
@@ -21,8 +21,8 @@ derivative = "1.0"
 log = "0.4"
 failure = "0.1"
 gfx-hal = "0.3"
-rendy-factory = { version = "0.4.0", path = "../factory" }
-rendy-util = { version = "0.4.0", path = "../util" }
+rendy-factory = { version = "0.4.1", path = "../factory" }
+rendy-util = { version = "0.4.1", path = "../util" }
 shaderc = { version = "0.5", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 spirv-reflect = { version = "0.2.1", optional = true }

--- a/texture/Cargo.toml
+++ b/texture/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rendy-texture"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["omni-viral <scareaangel@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/amethyst/rendy"
@@ -16,10 +16,10 @@ serde-1 = ["serde", "gfx-hal/serde"]
 profile = ["thread_profiler/thread_profiler"]
 
 [dependencies]
-rendy-memory = { version = "0.4.0", path = "../memory" }
-rendy-resource = { version = "0.4.0", path = "../resource" }
-rendy-factory = { version = "0.4.0", path = "../factory" }
-rendy-util = { version = "0.4.0", path = "../util" }
+rendy-memory = { version = "0.4.1", path = "../memory" }
+rendy-resource = { version = "0.4.1", path = "../resource" }
+rendy-factory = { version = "0.4.1", path = "../factory" }
+rendy-util = { version = "0.4.1", path = "../util" }
 
 gfx-hal = "0.3"
 

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rendy-util"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["omni-viral <scareaangel@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/amethyst/rendy"

--- a/util/src/types/vertex.rs
+++ b/util/src/types/vertex.rs
@@ -347,7 +347,7 @@ impl Ord for Attribute {
 #[cfg(feature = "serde")]
 mod serde_attribute {
     use serde::{
-        de::{Error, MapAccess, Visitor},
+        de::{Error, MapAccess, SeqAccess, Visitor},
         ser::SerializeStruct,
         Deserialize, Deserializer, Serialize, Serializer,
     };
@@ -380,6 +380,22 @@ mod serde_attribute {
                 type Value = super::Attribute;
                 fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
                     formatter.write_str("Attribute struct")
+                }
+
+                fn visit_seq<V>(self, mut seq: V) -> Result<super::Attribute, V::Error>
+                where
+                    V: SeqAccess<'de>,
+                {
+                    let element = seq
+                        .next_element()?
+                        .ok_or_else(|| V::Error::invalid_length(0, &self))?;
+                    let index = seq
+                        .next_element()?
+                        .ok_or_else(|| V::Error::invalid_length(1, &self))?;
+                    let name = seq
+                        .next_element::<String>()?
+                        .ok_or_else(|| V::Error::invalid_length(2, &self))?;
+                    Ok(super::Attribute::new(name, index, element))
                 }
                 fn visit_map<V: MapAccess<'de>>(
                     self,

--- a/wsi/Cargo.toml
+++ b/wsi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rendy-wsi"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["omni-viral <scareaangel@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/amethyst/rendy"
@@ -18,9 +18,9 @@ vulkan = ["rendy-util/vulkan"]
 no-slow-safety-checks = ["rendy-util/no-slow-safety-checks"]
 
 [dependencies]
-rendy-memory = { version = "0.4.0", path = "../memory" }
-rendy-resource = { version = "0.4.0", path = "../resource" }
-rendy-util = { version = "0.4.0", path = "../util" }
+rendy-memory = { version = "0.4.1", path = "../memory" }
+rendy-resource = { version = "0.4.1", path = "../resource" }
+rendy-util = { version = "0.4.1", path = "../util" }
 
 gfx-hal = "0.3"
 derivative = "1.0"


### PR DESCRIPTION
Amethyst uses 0.4.1 and this fixes deserialization of `rendy::util::types::vertex::Attribute` for binary formats that flatten structs to sequences instead of maps.

Relevant doc: https://serde.rs/deserialize-struct.html