### PR TITLE
call `Instance::destroy_surface`

### DIFF
--- a/factory/src/factory.rs
+++ b/factory/src/factory.rs
@@ -781,7 +781,13 @@ where
             self.instance.id(),
             "Resource is not owned by specified instance"
         );
-        drop(surface);
+        unsafe {
+            surface.dispose(
+                self.instance
+                    .as_instance()
+                    .expect("Cannot destroy surface without instance"),
+            );
+        }
     }
 
     /// Create target out of rendering surface.

--- a/wsi/src/lib.rs
+++ b/wsi/src/lib.rs
@@ -217,6 +217,16 @@ where
             usage,
         })
     }
+
+    /// Dispose of Surface.
+    ///
+    /// # Safety
+    ///
+    /// Surface must be not in use.
+    pub unsafe fn dispose(self, instance: &Instance<B>) {
+        self.assert_instance_owner(instance);
+        instance.destroy_surface(self.raw);
+    }
 }
 
 unsafe fn create_swapchain<B: Backend>(


### PR DESCRIPTION
## Description
call `gfx_hal::Instance::destroy_surface` when calling `rendy::Factory::destroy_surface`.

## Motivation and Context
fixes #263 (assumption: the surface is manually destroyed before the factory is dropped)

## How Has This Been Tested?
System:
* vulkan backend
* Linux
* used libVkLayer_khronos_validation.so

run:
`RUST_LOG=trace cargo run --example triangle --features="base init-winit shader-compiler vulkan"`

This should-not report something like: `For VkInstance 0x01234[], VkSurfaceKHR 0x56789[] has not been destroyed.`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] My code follows the code style of this project.
- [ ] ~My change requires a change to the documentation.~
- [ ] ~I have updated the documentation accordingly.~
- [ ] ~Updated the content of the book if this PR would make the book outdated.~
- [ ] I have added tests to cover my changes.
- [x] My code is used in an example (triangle)
